### PR TITLE
fix: USDC collision

### DIFF
--- a/components/AddressCard.tsx
+++ b/components/AddressCard.tsx
@@ -1169,7 +1169,7 @@ const UserReserveAssetList = ({ summaryOffset }: UserReserveAssetListProps) => {
           </Text>
         </Center>
       )}
-      {items.map((item) => {
+      {items.map((item, idx) => {
         const originalAsset = addressData?.[
           currentMarket
         ]?.fetchedData?.userReservesData?.find(
@@ -1177,7 +1177,7 @@ const UserReserveAssetList = ({ summaryOffset }: UserReserveAssetListProps) => {
         );
         return (
           <UserAssetItem
-            key={`${item.asset.symbol}-RESERVE`}
+            key={`${item.asset.symbol}-RESERVE-${idx}`}
             assetSymbol={item.asset.symbol}
             assetDetails={item.asset}
             usageAsCollateralEnabledOnUser={item.usageAsCollateralEnabledOnUser}


### PR DESCRIPTION
Adding the idx enables telling apart different tokens with the same name (such as USDC and USDC.e in Arbitrum which have different addresses while both have "USDC" as name)