### PR TITLE
feat: history mode

### DIFF
--- a/components/AddAssetDialog.tsx
+++ b/components/AddAssetDialog.tsx
@@ -30,7 +30,7 @@ export default function AddAssetDialog({ assetType }: AddAssetDialogProps) {
   const [open, setOpen] = React.useState(false);
   const [searchText, setSearchText] = React.useState("");
   const { addressData, currentMarket, addBorrowAsset, addReserveAsset } =
-    useAaveData("");
+    useAaveData("", true);
 
   const handleClose = () => {
     setSearchText("");

--- a/components/AddressCard.tsx
+++ b/components/AddressCard.tsx
@@ -69,7 +69,7 @@ type Props = {};
 
 const AddressCard = ({ }: Props) => {
   const { addressData, currentMarket, applyLiquidationScenario, isFetching } =
-    useAaveData("");
+    useAaveData("", true);
   const data = addressData?.[currentMarket] as HealthFactorData;
   const summaryRef = useRef<HTMLDivElement>(null);
   const summaryOffset: number = summaryRef?.current?.clientHeight || 0;
@@ -147,7 +147,7 @@ type HealthFactorAddressSummaryProps = {
 export const HealthFactorAddressSummary = ({
   addressData,
 }: HealthFactorAddressSummaryProps) => {
-  const { isFetching, currentAddress, currentMarket } = useAaveData("");
+  const { isFetching, currentAddress, currentMarket } = useAaveData("", true);
   const count = markets.filter(
     (market) => addressData?.[market.id]?.fetchedData?.healthFactor > -1
   ).length;
@@ -1077,7 +1077,7 @@ const LiquidationScenario = ({
 
 const ResetMarketButton = ({ }) => {
   const { addressData, currentMarket, resetCurrentMarketChanges } =
-    useAaveData("");
+    useAaveData("", true);
   const data = addressData?.[currentMarket];
 
   let isAnyModified: boolean = false;
@@ -1131,7 +1131,7 @@ const UserReserveAssetList = ({ summaryOffset }: UserReserveAssetListProps) => {
     setAssetPriceInUSD,
     setReserveAssetQuantity,
     setUseReserveAssetAsCollateral,
-  } = useAaveData("");
+  } = useAaveData("", true);
   const { i18n } = useLingui();
   const items: ImmutableArray<ReserveAssetDataItem> =
     addressData?.[currentMarket]?.workingData?.userReservesData || [];
@@ -1169,7 +1169,7 @@ const UserReserveAssetList = ({ summaryOffset }: UserReserveAssetListProps) => {
           </Text>
         </Center>
       )}
-      {items.map((item) => {
+      {items.map((item, idx) => {
         const originalAsset = addressData?.[
           currentMarket
         ]?.fetchedData?.userReservesData?.find(
@@ -1177,7 +1177,7 @@ const UserReserveAssetList = ({ summaryOffset }: UserReserveAssetListProps) => {
         );
         return (
           <UserAssetItem
-            key={`${item.asset.symbol}-RESERVE`}
+            key={`${item.asset.symbol}-RESERVE-${idx}`}
             assetSymbol={item.asset.symbol}
             assetDetails={item.asset}
             usageAsCollateralEnabledOnUser={item.usageAsCollateralEnabledOnUser}
@@ -1218,7 +1218,7 @@ const UserBorrowedAssetList = ({
     removeAsset,
     setAssetPriceInUSD,
     setBorrowedAssetQuantity,
-  } = useAaveData("");
+  } = useAaveData("", true);
   const { i18n } = useLingui();
   const items: ImmutableArray<BorrowedAssetDataItem> =
     addressData?.[currentMarket]?.workingData?.userBorrowsData || [];

--- a/components/AddressInput.tsx
+++ b/components/AddressInput.tsx
@@ -16,7 +16,7 @@ const AddressInput = ({ }: Props) => {
   const [showCopied, setShowCopied] = useState(false);
   const router = useRouter();
 
-  const { currentAddress, currentMarket } = useAaveData("");
+  const { currentAddress, currentMarket } = useAaveData("", true);
 
   const market = markets.find((market) => market.id === currentMarket);
 

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -21,6 +21,7 @@ import {
   Center,
   Indicator,
 } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
 import { BiGhost } from "react-icons/bi";
 import {
   getHealthFactorColor,
@@ -30,6 +31,7 @@ import {
 } from "../hooks/useAaveData";
 import { AbbreviatedEthereumAddress } from "./AddressCard";
 import { BsCheckLg } from "react-icons/bs";
+import BlockSelector from "./BlockSelector";
 
 const useStyles = createStyles((theme) => ({
   inner: {
@@ -61,9 +63,10 @@ const useStyles = createStyles((theme) => ({
 export default function AppBar() {
   const [hasMarketMenuOpened, setHasMarketMenuOpened] = React.useState(false);
   const { addressData, currentMarket, setCurrentMarket, currentAddress } =
-    useAaveData("");
+    useAaveData("", true);
   const { classes, cx } = useStyles();
   const router = useRouter();
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const numMarketsWithHF: number = markets.filter((market) => {
     const hasHF: boolean =
@@ -105,6 +108,9 @@ export default function AppBar() {
             DeFi Simulator
           </Title>
         </Group>
+
+        {/* Block Selector - Center (hidden on mobile) */}
+        {!isMobile && <BlockSelector />}
 
         <Indicator
           inline

--- a/components/BlockSelector.tsx
+++ b/components/BlockSelector.tsx
@@ -1,0 +1,201 @@
+import React, { useState, useEffect } from "react";
+import {
+  Group,
+  ActionIcon,
+  Badge,
+  Button,
+  Tooltip,
+  NumberInput,
+} from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import { FaChevronLeft, FaChevronRight, FaHome } from "react-icons/fa";
+import { BiTime } from "react-icons/bi";
+import { useAaveData } from "../hooks/useAaveData";
+
+const BlockSelector = () => {
+  const {
+    selectedBlockNumber,
+    isHistoryMode,
+    setSelectedBlockNumber,
+    goToLatestBlock,
+    addressData,
+    currentMarket,
+  } = useAaveData("", true);
+
+  const isXs = useMediaQuery("(max-width: 480px)");
+  const inputWidth = isXs ? 88 : 120;
+
+  // Get the actual fetched block number from the current market data
+  const fetchedBlockNumber =
+    addressData?.[currentMarket]?.fetchedBlockNumber ??
+    addressData?.[currentMarket]?.selectedBlockNumber;
+  const fetchError = addressData?.[currentMarket]?.fetchError;
+
+  const [inputValue, setInputValue] = useState<number | undefined>(undefined);
+
+  // Handle fetch errors (e.g., future block numbers)
+  useEffect(() => {
+    if (fetchError && fetchError.length > 0) {
+      // Clear input and return to latest block
+      setInputValue(undefined);
+      goToLatestBlock();
+    }
+  }, [fetchError]);
+
+  // Sync input with global state when exiting history mode
+  useEffect(() => {
+    if (!isHistoryMode && selectedBlockNumber === undefined) {
+      // Clear input when history mode is exited
+      setInputValue(undefined);
+    }
+  }, [isHistoryMode, selectedBlockNumber]);
+
+  useEffect(() => {
+    if (isHistoryMode && fetchedBlockNumber !== undefined) {
+      setInputValue(fetchedBlockNumber);
+    }
+  }, [fetchedBlockNumber, isHistoryMode]);
+
+  const handleBlockNumberSubmit = () => {
+    if (inputValue !== undefined && inputValue >= 0) {
+      setSelectedBlockNumber(inputValue);
+    }
+  };
+
+  const handlePreviousBlock = () => {
+    const currentBlock = fetchedBlockNumber;
+    if (currentBlock && currentBlock > 0) {
+      const newBlock = currentBlock - 1;
+      setInputValue(newBlock);
+      setSelectedBlockNumber(newBlock);
+    }
+  };
+
+  const handleNextBlock = () => {
+    const currentBlock = fetchedBlockNumber;
+    if (currentBlock) {
+      const newBlock = currentBlock + 1;
+      setInputValue(newBlock);
+      setSelectedBlockNumber(newBlock);
+    }
+  };
+
+  const handleGoToLatest = () => {
+    goToLatestBlock();
+    setInputValue(undefined);
+  };
+
+  const handleInputChange = (value: number | "") => {
+    setInputValue(value === "" ? undefined : value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter") {
+      handleBlockNumberSubmit();
+    } else if (event.key === "ArrowUp" && fetchedBlockNumber !== undefined) {
+      event.preventDefault();
+      handleNextBlock();
+    } else if (
+      event.key === "ArrowDown" &&
+      fetchedBlockNumber &&
+      fetchedBlockNumber > 0
+    ) {
+      event.preventDefault();
+      handlePreviousBlock();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      handleGoToLatest();
+    }
+  };
+
+  return (
+    <Group spacing="xs" align="center" noWrap>
+      {/* History Mode Indicator */}
+      {isHistoryMode && !isXs && (
+        <Badge
+          color="orange"
+          variant="filled"
+          leftSection={<BiTime size={12} />}
+          size="sm"
+        >
+          History Mode
+        </Badge>
+      )}
+
+      {/* Block Navigation Controls */}
+      <Group spacing={4} align="center" noWrap>
+        <Tooltip label="Previous Block" position="bottom">
+          <ActionIcon
+            variant="subtle"
+            size="sm"
+            onClick={handlePreviousBlock}
+            disabled={!fetchedBlockNumber || fetchedBlockNumber <= 0}
+            aria-label="Previous block"
+          >
+            <FaChevronLeft size={12} />
+          </ActionIcon>
+        </Tooltip>
+
+        <Tooltip
+          label="Enter: Go to block | ↑↓: Navigate | Esc: Latest"
+          position="bottom"
+          multiline
+        >
+          <NumberInput
+            placeholder="Block number"
+            value={inputValue ?? ""}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            size="xs"
+            style={{ width: inputWidth }}
+            min={0}
+            hideControls
+            aria-label="Block number"
+          />
+        </Tooltip>
+
+        <Tooltip label="Next Block" position="bottom">
+          <ActionIcon
+            variant="subtle"
+            size="sm"
+            onClick={handleNextBlock}
+            disabled={!fetchedBlockNumber}
+            aria-label="Next block"
+          >
+            <FaChevronRight size={12} />
+          </ActionIcon>
+        </Tooltip>
+      </Group>
+
+      {/* Action Buttons */}
+      <Group spacing={4} noWrap>
+        {!isXs && (
+          <Button
+            size="xs"
+            variant="subtle"
+            onClick={handleBlockNumberSubmit}
+            disabled={inputValue === selectedBlockNumber}
+          >
+            Go
+          </Button>
+        )}
+
+        {isHistoryMode && !isXs && (
+          <Tooltip label="Go to Latest Block" position="bottom">
+            <Button
+              size="xs"
+              variant="subtle"
+              leftIcon={<FaHome size={12} />}
+              onClick={handleGoToLatest}
+              aria-label="Go to latest block"
+            >
+              Latest
+            </Button>
+          </Tooltip>
+        )}
+      </Group>
+    </Group>
+  );
+};
+
+export default BlockSelector;

--- a/hooks/useAaveData.ts
+++ b/hooks/useAaveData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useHookstate, State } from "@hookstate/core";
 import * as pools from "@bgd-labs/aave-address-book";
 
@@ -6,7 +6,6 @@ import { HealthFactorDataStore } from "../store/healthFactorDataStore";
 
 import { ChainId } from "@aave/contract-helpers";
 import BigNumber from "bignumber.js";
-import { getAaveData } from "../pages/api/aave";
 
 export type HealthFactorData = {
   address: string; // e.g. 0xc...123a or stani.eth
@@ -19,6 +18,8 @@ export type HealthFactorData = {
   availableAssets?: AssetDetails[];
   fetchedData?: AaveHealthFactorData;
   workingData?: AaveHealthFactorData;
+  selectedBlockNumber?: number; // Track which block this data was fetched from
+  fetchedBlockNumber?: number; // Actual chain block used for the fetch
 };
 
 export type AaveHealthFactorData = {
@@ -35,19 +36,25 @@ export type AaveHealthFactorData = {
   userEmodeCategoryId?: number;
   isInIsolationMode?: boolean;
   txHistory: TxHistory;
-}
+};
 
 export type TxHistory = {
-  data: TxHistoryItem[],
-  isFetching: boolean,
-  fetchError: string,
-  lastFetched: number
-}
+  data: TxHistoryItem[];
+  isFetching: boolean;
+  fetchError: string;
+  lastFetched: number;
+};
 
 export type TxHistoryItem = {
   id: string;
   txHash: string;
-  action: "Borrow" | "Repay" | "Supply" | "Deposit" | "RedeemUnderlying" | "LiquidationCall";
+  action:
+    | "Borrow"
+    | "Repay"
+    | "Supply"
+    | "Deposit"
+    | "RedeemUnderlying"
+    | "LiquidationCall";
   amount?: number; // absent for liquidationCall
   reserve?: TxHistoryReserveItem; // absent for liquidationCall
   timestamp: number;
@@ -61,14 +68,14 @@ export type TxHistoryItem = {
   principalAmount?: number;
   principalReserve?: TxHistoryReserveItem;
   principalPriceUSD?: string;
-}
+};
 
 export type TxHistoryReserveItem = {
   symbol: string;
   decimals: string;
   name: string;
   underlyingAsset: string;
-}
+};
 
 export type ReserveAssetDataItem = {
   asset: AssetDetails;
@@ -127,7 +134,7 @@ export type AssetDetails = {
   totalStableDebt?: number;
   totalVariableDebt?: number;
   totalLiquidity?: number;
-  flashLoanEnabled?: boolean
+  flashLoanEnabled?: boolean;
   // Incentive Data
   supplyAPY?: number;
   variableBorrowAPY?: number;
@@ -135,7 +142,6 @@ export type AssetDetails = {
   supplyAPR?: number;
   variableBorrowAPR?: number;
   stableBorrowAPR?: number;
-
 };
 
 /**
@@ -165,11 +171,11 @@ export type AaveMarketDataType = {
   addresses: {
     LENDING_POOL_ADDRESS_PROVIDER: string;
     UI_POOL_DATA_PROVIDER: string;
-    UI_INCENTIVE_DATA_PROVIDER: string
+    UI_INCENTIVE_DATA_PROVIDER: string;
   };
   explorer: string;
   explorerName: string;
-  subgraphUrl: string
+  subgraphUrl: string;
 };
 
 export const markets: AaveMarketDataType[] = [
@@ -178,33 +184,33 @@ export const markets: AaveMarketDataType[] = [
     id: "ETHEREUM_V2",
     title: "Ethereum v2",
     chainId: ChainId.mainnet,
-    api: `https://eth-mainnet.alchemyapi.io/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
+    api: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
     addresses: {
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV2Ethereum.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: pools.AaveV2Ethereum.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: pools.AaveV2Ethereum.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER:
+        pools.AaveV2Ethereum.UI_INCENTIVE_DATA_PROVIDER,
     },
     explorer: "https://etherscan.io/address/{{ADDRESS}}",
     explorerName: "Etherscan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2',
-
+    subgraphUrl: "https://api.thegraph.com/subgraphs/name/aave/protocol-v2",
   },
   {
     v3: true,
     id: "ETHEREUM_V3",
     title: "Ethereum v3",
     chainId: ChainId.mainnet,
-    api: `https://eth-mainnet.alchemyapi.io/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
+    api: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
     addresses: {
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV3Ethereum.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0x194324C9Af7f56E22F1614dD82E18621cb9238E7",
-      UI_INCENTIVE_DATA_PROVIDER: "0x5a40cDe2b76Da2beD545efB3ae15708eE56aAF9c"
+      UI_INCENTIVE_DATA_PROVIDER: "0x5a40cDe2b76Da2beD545efB3ae15708eE56aAF9c",
     },
     explorer: "https://etherscan.io/address/{{ADDRESS}}",
     explorerName: "Etherscan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v3',
+    subgraphUrl: "https://api.thegraph.com/subgraphs/name/aave/protocol-v3",
   },
   {
     v3: true,
@@ -216,11 +222,12 @@ export const markets: AaveMarketDataType[] = [
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV3Arbitrum.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0xc0179321f0825c3e0F59Fe7Ca4E40557b97797a3", // pools.AaveV3Arbitrum.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: "0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4" // pools.AaveV3Arbitrum.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER: "0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4", // pools.AaveV3Arbitrum.UI_INCENTIVE_DATA_PROVIDER
     },
     explorer: "https://arbiscan.io/address/{{ADDRESS}}",
     explorerName: "Arbiscan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v3-arbitrum',
+    subgraphUrl:
+      "https://api.thegraph.com/subgraphs/name/aave/protocol-v3-arbitrum",
   },
   {
     v3: true,
@@ -232,11 +239,12 @@ export const markets: AaveMarketDataType[] = [
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV3Optimism.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0x86b0521f92a554057e54B93098BA2A6Aaa2F4ACB", // pools.AaveV3Optimism.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: "0xc0179321f0825c3e0F59Fe7Ca4E40557b97797a3" // pools.AaveV3Optimism.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER: "0xc0179321f0825c3e0F59Fe7Ca4E40557b97797a3", // pools.AaveV3Optimism.UI_INCENTIVE_DATA_PROVIDER
     },
     explorer: "https://optimistic.etherscan.io/address/{{ADDRESS}}",
     explorerName: "Optimistic Etherscan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v3-optimism',
+    subgraphUrl:
+      "https://api.thegraph.com/subgraphs/name/aave/protocol-v3-optimism",
   },
   {
     v3: true,
@@ -245,14 +253,13 @@ export const markets: AaveMarketDataType[] = [
     chainId: ChainId.base,
     api: `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
     addresses: {
-      LENDING_POOL_ADDRESS_PROVIDER:
-        pools.AaveV3Base.POOL_ADDRESSES_PROVIDER,
+      LENDING_POOL_ADDRESS_PROVIDER: pools.AaveV3Base.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4", // pools.AaveV3Base.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: "0x5c5228aC8BC1528482514aF3e27E692495148717" // pools.AaveV3Base.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER: "0x5c5228aC8BC1528482514aF3e27E692495148717", // pools.AaveV3Base.UI_INCENTIVE_DATA_PROVIDER
     },
     explorer: "https://basescan.org/address/{{ADDRESS}}",
     explorerName: "BaseScan",
-    subgraphUrl: "" // Not set up yet
+    subgraphUrl: "", // Not set up yet
   },
   {
     v3: false,
@@ -264,11 +271,12 @@ export const markets: AaveMarketDataType[] = [
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV2Polygon.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: pools.AaveV2Polygon.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: pools.AaveV2Polygon.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER:
+        pools.AaveV2Polygon.UI_INCENTIVE_DATA_PROVIDER,
     },
     explorer: "https://polygonscan.com/address/{{ADDRESS}}",
     explorerName: "PolygonScan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic',
+    subgraphUrl: "https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic",
   },
   {
     v3: true,
@@ -280,11 +288,12 @@ export const markets: AaveMarketDataType[] = [
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV3Polygon.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0xE92cd6164CE7DC68e740765BC1f2a091B6CBc3e4", // pools.AaveV3Polygon.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: "0x5c5228aC8BC1528482514aF3e27E692495148717" // pools.AaveV3Polygon.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER: "0x5c5228aC8BC1528482514aF3e27E692495148717", // pools.AaveV3Polygon.UI_INCENTIVE_DATA_PROVIDER
     },
     explorer: "https://polygonscan.com/address/{{ADDRESS}}",
     explorerName: "PolygonScan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v3-polygon',
+    subgraphUrl:
+      "https://api.thegraph.com/subgraphs/name/aave/protocol-v3-polygon",
   },
   {
     v3: false,
@@ -296,11 +305,13 @@ export const markets: AaveMarketDataType[] = [
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV2Avalanche.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: pools.AaveV2Avalanche.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: pools.AaveV2Avalanche.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER:
+        pools.AaveV2Avalanche.UI_INCENTIVE_DATA_PROVIDER,
     },
     explorer: "https://avascan.info/blockchain/all/address/{{ADDRESS}}",
     explorerName: "AvaScan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2-avalanche',
+    subgraphUrl:
+      "https://api.thegraph.com/subgraphs/name/aave/protocol-v2-avalanche",
   },
   {
     v3: true,
@@ -312,11 +323,12 @@ export const markets: AaveMarketDataType[] = [
       LENDING_POOL_ADDRESS_PROVIDER:
         pools.AaveV3Avalanche.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0x374a2592f0265b3bb802d75809e61b1b5BbD85B7", // pools.AaveV3Avalanche.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: "0xC81CCebEA6A14bA007b96C0a1600D0bA0Df383a8" // pools.AaveV3Avalanche.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER: "0xC81CCebEA6A14bA007b96C0a1600D0bA0Df383a8", // pools.AaveV3Avalanche.UI_INCENTIVE_DATA_PROVIDER
     },
     explorer: "https://avascan.info/blockchain/all/address/{{ADDRESS}}",
     explorerName: "AvaScan",
-    subgraphUrl: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v3-avalanche',
+    subgraphUrl:
+      "https://api.thegraph.com/subgraphs/name/aave/protocol-v3-avalanche",
   },
   /*
   {
@@ -374,12 +386,12 @@ export const markets: AaveMarketDataType[] = [
     addresses: {
       LENDING_POOL_ADDRESS_PROVIDER: pools.AaveV3BNB.POOL_ADDRESSES_PROVIDER,
       UI_POOL_DATA_PROVIDER: "0xb12e82DF057BF16ecFa89D7D089dc7E5C1Dc057B", // pools.AaveV3BNB.UI_POOL_DATA_PROVIDER,
-      UI_INCENTIVE_DATA_PROVIDER: "0x86b0521f92a554057e54B93098BA2A6Aaa2F4ACB" // pools.AaveV3BNB.UI_INCENTIVE_DATA_PROVIDER
+      UI_INCENTIVE_DATA_PROVIDER: "0x86b0521f92a554057e54B93098BA2A6Aaa2F4ACB", // pools.AaveV3BNB.UI_INCENTIVE_DATA_PROVIDER
     },
     explorer: "https://bscscan.com/address/{{ADDRESS}}",
     explorerName: "BSC Scan",
     subgraphUrl: "",
-  }
+  },
 ];
 
 /** hook to fetch user aave data
@@ -393,140 +405,212 @@ export const markets: AaveMarketDataType[] = [
     setCurrentMarket, }
  */
 export function useAaveData(address: string, preventFetch: boolean = false) {
-  const [isFetching, setIsFetching] = useState(false);
   const store = useHookstate(HealthFactorDataStore);
   const state = store.get({ noproxy: true });
-  const { currentAddress, addressData, currentMarket } = state;
+  const {
+    currentAddress,
+    addressData,
+    currentMarket,
+    selectedBlockNumber,
+    isHistoryMode,
+  } = state;
   const data = addressData?.[currentAddress];
+  if (address?.length === 0 || address === "DEBUG")
+    address = currentAddress || "";
   const addressProvided: boolean = !!(address && address?.length > 0);
-  if (address?.length === 0 || address === "DEBUG") address = currentAddress || "";
 
   const isLoadingAny = !!markets.find(
     (market) => data?.[market.id]?.isFetching === true
   );
-
-  const deps = [currentAddress, addressProvided, isLoadingAny];
+  const isLoadingCurrentMarket = !!data?.[currentMarket]?.isFetching;
 
   useEffect(() => {
     if (preventFetch) return;
-    if (addressProvided && !isLoadingAny) {
-      markets.map((market) => {
+    if (addressProvided && !isLoadingAny && address && address.length > 0) {
+      const marketsToFetch = isHistoryMode
+        ? markets.filter((market) => market.id === currentMarket)
+        : markets;
+
+      marketsToFetch.forEach((market) => {
         const existingData = data?.[market.id];
         const lastFetched = existingData?.lastFetched;
-        if (lastFetched) return;
-        if (existingData?.isFetching) return;
-        setIsFetching(true);
+        const existingBlockNumber = existingData?.selectedBlockNumber;
+        const shouldRefetch =
+          !lastFetched || selectedBlockNumber !== existingBlockNumber;
+
+        if (!shouldRefetch || existingData?.isFetching) return;
+
+        if (selectedBlockNumber !== existingBlockNumber && existingData) {
+          store.addressData.nested(address).nested(market.id).merge({
+            isFetching: true,
+            lastFetched: 0,
+            selectedBlockNumber,
+          });
+        }
+
         createInitial(market);
         const fetchData = async () => {
           const options = {
             method: "POST",
-            body: JSON.stringify({ address, marketId: market.id }),
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              address,
+              marketId: market.id,
+              blockNumber: selectedBlockNumber,
+            }),
           };
-          //const response: Response = await fetch("/api/aave", options);
-          const data: HealthFactorData = await getAaveData(address, market);
-          store.addressData.nested(address).merge({ [market.id]: data });
-          /*
-          if (response?.ok) {
-            // ok, use the response
-            const hfData: HealthFactorData = await response.json();
-            store.addressData.nested(address).merge({ [market.id]: hfData });
-          } else {
-            // monkey up an errored HealthFactorData object
-            const res = await response.json();
-            const message: string = `${response.statusText}: --- ${res?.message ?? ""
+          const controller = new AbortController();
+          const timeoutId = window.setTimeout(() => controller.abort(), 12000);
+
+          try {
+            const response: Response = await fetch("/api/aave", {
+              ...options,
+              signal: controller.signal,
+            });
+            if (response?.ok) {
+              const hfData: HealthFactorData = await response.json();
+              store.addressData.nested(address).merge({ [market.id]: hfData });
+            } else {
+              const res = await response.json();
+              const message: string = `${response.statusText}: --- ${
+                res?.message ?? ""
               }`;
+              const hfData: HealthFactorData = {
+                address,
+                resolvedAddress: address,
+                fetchError: message,
+                isFetching: false,
+                lastFetched: Date.now(),
+                market,
+                marketReferenceCurrencyPriceInUSD: 1,
+                selectedBlockNumber,
+              };
+              store.addressData.nested(address).merge({ [market.id]: hfData });
+            }
+          } catch (error) {
+            const message =
+              error instanceof DOMException && error.name === "AbortError"
+                ? "Request timed out while loading market data"
+                : `Network error: ${error}`;
+            console.error("Error fetching data:", error);
             const hfData: HealthFactorData = {
               address,
+              resolvedAddress: address,
               fetchError: message,
               isFetching: false,
               lastFetched: Date.now(),
               market,
               marketReferenceCurrencyPriceInUSD: 1,
+              selectedBlockNumber,
             };
             store.addressData.nested(address).merge({ [market.id]: hfData });
+          } finally {
+            window.clearTimeout(timeoutId);
           }
-          */
         };
 
         fetchData();
-
       });
     }
-  }, deps);
+  }, [
+    address,
+    addressProvided,
+    currentMarket,
+    isHistoryMode,
+    isLoadingAny,
+    preventFetch,
+    selectedBlockNumber,
+  ]);
 
   useEffect(() => {
     if (address) store.currentAddress.set(address);
   }, [address]);
 
-  useEffect(() => {
-    if (!isFetching) return;
-    if (!markets.find((market) => data?.[market.id]?.isFetching)) {
-      setIsFetching(false);
-    }
-  }, [isLoadingAny]);
+  // Note: We removed the aggressive history mode exit here
+  // History mode now only exits when explicitly switching markets or when errors occur
 
   // After fetching, if the current market doesn't have a position but another
   // one does, select the market that has a position (prefer highest reserve balance).
   useEffect(() => {
-    if (!isFetching && addressProvided) {
-      const currentMarketHasPosition =
-        data?.[currentMarket].workingData?.healthFactor &&
-        (data?.[currentMarket]?.workingData?.healthFactor ?? -1) > -1;
+    if (!addressProvided) return;
 
-      const currentMarketHasEdits =
-        data?.[currentMarket]?.workingData?.healthFactor?.toFixed(2) !==
-        data?.[currentMarket]?.fetchedData?.healthFactor?.toFixed(2);
+    const currentMarketHasPosition =
+      (data?.[currentMarket]?.workingData?.healthFactor ?? -1) > -1;
 
-      // Don't perform the auto-select if the user is actively editing the current market.
-      if (currentMarketHasPosition && currentMarketHasEdits) return;
+    const currentMarketHasEdits =
+      data?.[currentMarket]?.workingData?.healthFactor?.toFixed(2) !==
+      data?.[currentMarket]?.fetchedData?.healthFactor?.toFixed(2);
 
-      const marketWithPosition = markets
-        .sort((marketA, marketB) => {
-          const marketDataA = data?.[marketA.id];
-          const marketDataB = data?.[marketB.id];
+    // Don't perform the auto-select if the user is actively editing the current market.
+    if (currentMarketHasPosition && currentMarketHasEdits) return;
 
-          const totalCollA =
-            marketDataA?.workingData?.totalCollateralMarketReferenceCurrency ||
-            0;
-          const totalCollB =
-            marketDataB?.workingData?.totalCollateralMarketReferenceCurrency ||
-            0;
+    // Don't auto-switch markets when in history mode - user explicitly selected a chain
+    if (isHistoryMode) return;
 
-          const priceA = marketDataA?.marketReferenceCurrencyPriceInUSD || 0;
-          const priceB = marketDataB?.marketReferenceCurrencyPriceInUSD || 0;
+    // Don't auto-switch markets if we're currently fetching historical data
+    if (selectedBlockNumber !== undefined) return;
 
-          return totalCollB * priceB - totalCollA * priceA;
-        })
-        .find(
-          (market) =>
-            data?.[market.id]?.workingData?.healthFactor &&
-            (data?.[market.id]?.workingData?.healthFactor ?? -1) > -1
-        );
-      // This guard doesn't make much sense but for some reason this useEffect was being triggered
-      // sometimes even when the markets hadn't just finished loading. We only want to apply
-      // this logic right after loading.
-      const didFetchRecently = !!markets.find(
-        (market) => data?.[market.id]?.lastFetched > Date.now() - 1000
+    if (currentMarketHasPosition) return;
+
+    const marketWithPosition = [...markets]
+      .sort((marketA, marketB) => {
+        const marketDataA = data?.[marketA.id];
+        const marketDataB = data?.[marketB.id];
+
+        const totalCollA =
+          marketDataA?.workingData?.totalCollateralMarketReferenceCurrency || 0;
+        const totalCollB =
+          marketDataB?.workingData?.totalCollateralMarketReferenceCurrency || 0;
+
+        const priceA = marketDataA?.marketReferenceCurrencyPriceInUSD || 0;
+        const priceB = marketDataB?.marketReferenceCurrencyPriceInUSD || 0;
+
+        return totalCollB * priceB - totalCollA * priceA;
+      })
+      .find(
+        (market) => (data?.[market.id]?.workingData?.healthFactor ?? -1) > -1
       );
-      if (marketWithPosition && didFetchRecently) {
-        setCurrentMarket(marketWithPosition.id);
-      }
+
+    if (marketWithPosition && currentMarket !== marketWithPosition.id) {
+      setCurrentMarket(marketWithPosition.id);
     }
-  }, [isFetching]);
+  }, [
+    addressProvided,
+    currentMarket,
+    data,
+    isHistoryMode,
+    selectedBlockNumber,
+  ]);
 
   const createInitial = (market: AaveMarketDataType) => {
     const hf: HealthFactorData = {
       address,
+      resolvedAddress: address, // Use address as resolved address initially
       fetchError: "",
       isFetching: true,
       lastFetched: 0,
       market,
       marketReferenceCurrencyPriceInUSD: 0,
+      selectedBlockNumber: selectedBlockNumber,
+      fetchedBlockNumber: undefined,
     };
     store.addressData.nested(address).merge({ [market.id]: hf });
   };
 
   const setCurrentMarket = (marketId: string) => {
+    if (currentMarket !== marketId && isHistoryMode) {
+      const oldMarket = markets.find((market) => market.id === currentMarket);
+      const newMarket = markets.find((market) => market.id === marketId);
+      const isSameChain = oldMarket?.chainId === newMarket?.chainId;
+
+      if (!isSameChain) {
+        store.isHistoryMode.set(false);
+        store.selectedBlockNumber.set(undefined);
+      }
+    }
+
     store.currentMarket.set(marketId);
   };
 
@@ -542,7 +626,7 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
       totalBorrows: 0,
       totalBorrowsUSD: 0,
       totalBorrowsMarketReferenceCurrency: 0,
-      stableBorrowAPY: 0
+      stableBorrowAPY: 0,
     };
 
     const workingData = store.addressData.nested(address)?.[currentMarket]
@@ -586,13 +670,13 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
 
     assetType === "RESERVE"
       ? reserves.set((p) => {
-        p.splice(itemIndex, 1);
-        return p;
-      })
+          p.splice(itemIndex, 1);
+          return p;
+        })
       : borrows.set((p) => {
-        p.splice(itemIndex, 1);
-        return p;
-      });
+          p.splice(itemIndex, 1);
+          return p;
+        });
 
     updateAllDerivedHealthFactorData();
   };
@@ -649,11 +733,13 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
     );
     if (borrowItem && borrowItem?.asset.priceInUSD.get() !== price)
       borrowItem.asset.priceInUSD.set(price);
+
     updateAllDerivedHealthFactorData();
   };
 
   const setTxHistory = (address: string, history: TxHistory) => {
-    const workingData = store.addressData.nested(address)?.[currentMarket]?.workingData as State<AaveHealthFactorData>;
+    const workingData = store.addressData.nested(address)?.[currentMarket]
+      ?.workingData as State<AaveHealthFactorData>;
     if (workingData) workingData.txHistory?.set(history);
   };
 
@@ -689,7 +775,7 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
   const updateAllDerivedHealthFactorData = () => {
     const currentMarketReferenceCurrencyPriceInUSD: number = store.addressData
       .nested(address)
-    [currentMarket].marketReferenceCurrencyPriceInUSD.get();
+      [currentMarket].marketReferenceCurrencyPriceInUSD.get();
 
     const healthFactorItem = store.addressData.nested(address)?.[
       currentMarket
@@ -708,10 +794,31 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
     healthFactorItem.workingData.set(updatedWorkingData);
   };
 
-  //console.log({ data })
+  const setSelectedBlockNumber = (blockNumber?: number) => {
+    store.selectedBlockNumber.set(blockNumber);
+    store.isHistoryMode.set(blockNumber !== undefined);
+  };
+
+  const setHistoryMode = (enabled: boolean) => {
+    store.isHistoryMode.set(enabled);
+    if (!enabled) {
+      store.selectedBlockNumber.set(undefined);
+    }
+  };
+
+  const goToLatestBlock = () => {
+    // Clear the last fetched timestamp to force a refetch at latest block
+    if (data?.[currentMarket]) {
+      store.addressData.nested(address).nested(currentMarket).merge({
+        lastFetched: 0,
+        selectedBlockNumber: undefined,
+      });
+    }
+    setSelectedBlockNumber(undefined);
+  };
 
   return {
-    isFetching: isLoadingAny,
+    isFetching: isLoadingCurrentMarket,
     currentAddress,
     currentMarket,
     addressData: data,
@@ -727,7 +834,13 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
     setAssetPriceInUSD,
     applyLiquidationScenario,
     setUseReserveAssetAsCollateral,
-    setTxHistory
+    setTxHistory,
+    // Block number functionality
+    selectedBlockNumber,
+    isHistoryMode,
+    setSelectedBlockNumber,
+    setHistoryMode,
+    goToLatestBlock,
   };
 }
 
@@ -742,7 +855,9 @@ export const getHealthFactorColor = (hf: number = 0) => {
 };
 
 export const isStablecoinAsset = (asset: AssetDetails) => {
-  return !!["DAI", "USD", "GHO", "EUR", "MAI"].find(symbol => asset.symbol?.toUpperCase().includes(symbol));
+  return !!["DAI", "USD", "GHO", "EUR", "MAI"].find((symbol) =>
+    asset.symbol?.toUpperCase().includes(symbol)
+  );
 };
 
 export const isActiveAsset = (asset: AssetDetails) => {
@@ -786,7 +901,7 @@ export const getEligibleLiquidationScenarioReserves = (
   const exceedsMinResPct: boolean =
     cumulativeReserveMRCValue >
     hfData.totalCollateralMarketReferenceCurrency *
-    (MINIMUM_CUMULATIVE_RESERVE_PCT / 100);
+      (MINIMUM_CUMULATIVE_RESERVE_PCT / 100);
   const exceedsMinResUSD: boolean =
     cumulativeReserveUSDValue > MINIMUM_CUMULATIVE_RESERVE_USD;
 
@@ -906,17 +1021,23 @@ export const updateDerivedHealthFactorData = (
         updatedUnderlyingBalanceMarketReferenceCurrency
       );
 
-      const isEmode: boolean = !!reserveItem.asset.eModeCategoryId && (reserveItem.asset.eModeCategoryId === data.userEmodeCategoryId);
+      const isEmode: boolean =
+        !!reserveItem.asset.eModeCategoryId &&
+        reserveItem.asset.eModeCategoryId === data.userEmodeCategoryId;
       const lt: number = isEmode
         ? reserveItem.asset.eModeLiquidationThreshold || 0
-        : reserveItem.asset.reserveLiquidationThreshold || 0
+        : reserveItem.asset.reserveLiquidationThreshold || 0;
 
       const ltv: number = isEmode
         ? reserveItem.asset.eModeLtv || 0
-        : reserveItem.asset.baseLTVasCollateral || 0
+        : reserveItem.asset.baseLTVasCollateral || 0;
 
-      const itemReserveLiquidationThreshold: BigNumber = new BigNumber(lt).dividedBy(10000);
-      const itemBaseLoanToValue: BigNumber = new BigNumber(ltv).dividedBy(10000);
+      const itemReserveLiquidationThreshold: BigNumber = new BigNumber(
+        lt
+      ).dividedBy(10000);
+      const itemBaseLoanToValue: BigNumber = new BigNumber(ltv).dividedBy(
+        10000
+      );
 
       weightedReservesETH = weightedReservesETH.plus(
         itemReserveLiquidationThreshold.multipliedBy(
@@ -1169,15 +1290,15 @@ export const getCalculatedLiquidationScenario = (
 
       let priceDecrement = decrementPercentage
         ? // Use the uniform percentage, if we  have it
-        Math.max(0.01, (decrementPercentage * asset.priceInUSD) / 100)
+          Math.max(0.01, (decrementPercentage * asset.priceInUSD) / 100)
         : // Else use an approximation based on the difference between current hf and HF_LIMIT
-        Math.max(
-          0.01,
-          Math.min(
-            asset.priceInUSD * ((hf - HF_LIMIT) * 0.45),
-            asset.priceInUSD * 0.5
-          )
-        );
+          Math.max(
+            0.01,
+            Math.min(
+              asset.priceInUSD * ((hf - HF_LIMIT) * 0.45),
+              asset.priceInUSD * 0.5
+            )
+          );
 
       priceDecrement =
         Math.round((priceDecrement + Number.EPSILON) * 100) / 100;
@@ -1230,17 +1351,21 @@ export const getCalculatedLiquidationScenario = (
 };
 
 export const getIconNameFromAssetSymbol = (assetSymbol: string) => {
-  return assetSymbol
-    ?.toLowerCase()
-    .replace(".e", "")
-    .replace(".b", "")
-    .replace("m.", "")
-    .replace("btcb", "btc") || "";
+  return (
+    assetSymbol
+      ?.toLowerCase()
+      .replace(".e", "")
+      .replace(".b", "")
+      .replace("m.", "")
+      .replace("btcb", "btc") || ""
+  );
 };
 
 export const getIconNameFromMarket = (market?: AaveMarketDataType) => {
-  return market?.id
-    ?.split("_")[0]
-    .replace("BNB", "binance") // special case... follow aave interface convention
-    .toLowerCase() || "";
+  return (
+    market?.id
+      ?.split("_")[0]
+      .replace("BNB", "binance") // special case... follow aave interface convention
+      .toLowerCase() || ""
+  );
 };

--- a/hooks/useAaveHistory.ts
+++ b/hooks/useAaveHistory.ts
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
-import { AaveMarketDataType, TxHistory, TxHistoryItem, markets, useAaveData } from './useAaveData';
+import { useEffect } from "react";
+import { TxHistory, useAaveData } from './useAaveData';
 
 /** hook to fetch user aave tx data
  * @returns { history: TxHistory }
  */
 export function useAaveHistory(address: string, resolvedAddress: string) {
-    const { addressData, setTxHistory, currentMarket } = useAaveData(address);
+    const { addressData, setTxHistory, currentMarket } = useAaveData(address, true);
     const history = addressData?.[currentMarket]?.workingData?.txHistory;
     const isFetchingHistory: boolean = !!history?.isFetching;
 
@@ -14,28 +14,49 @@ export function useAaveHistory(address: string, resolvedAddress: string) {
         if (!!history?.lastFetched) return;
 
         const fetchData = async () => {
-            const options = {
-                method: "POST",
-                body: JSON.stringify({ address: resolvedAddress?.toLowerCase(), marketId: currentMarket }),
-            };
-            const response: Response = await fetch("/api/aave/history", options);
-
             const txHistory: TxHistory = {
                 data: [],
                 isFetching: true,
                 fetchError: "",
                 lastFetched: 0
             }
+            const controller = new AbortController();
+            const timeoutId = window.setTimeout(() => controller.abort(), 12000);
 
-            if (response?.ok) {
-                // ok, use the response data
-                const data = await response.json() || [];
-                setTxHistory(address, { ...txHistory, data, isFetching: false, lastFetched: Date.now() })
-            } else {
-                // monkey up an errored TxHistory object
-                const data = await response.json();
-                const message: string = `${response.statusText}: --- ${data?.message ?? ""}`;
-                setTxHistory(address, { ...txHistory, isFetching: false, lastFetched: Date.now(), fetchError: message })
+            try {
+                const options = {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ address: resolvedAddress?.toLowerCase(), marketId: currentMarket }),
+                };
+                const response: Response = await fetch("/api/aave/history", {
+                    ...options,
+                    signal: controller.signal,
+                });
+
+                if (response?.ok) {
+                    const data = await response.json() || [];
+                    setTxHistory(address, { ...txHistory, data, isFetching: false, lastFetched: Date.now() })
+                } else {
+                    const data = await response.json();
+                    const message: string = `${response.statusText}: --- ${data?.message ?? ""}`;
+                    setTxHistory(address, { ...txHistory, isFetching: false, lastFetched: Date.now(), fetchError: message })
+                }
+            } catch (error) {
+                const message =
+                    error instanceof DOMException && error.name === "AbortError"
+                        ? "Request timed out while loading transaction history"
+                        : `Network error: ${error}`;
+                setTxHistory(address, {
+                    ...txHistory,
+                    isFetching: false,
+                    lastFetched: Date.now(),
+                    fetchError: message,
+                })
+            } finally {
+                window.clearTimeout(timeoutId);
             }
         };
         createInitial();

--- a/pages/api/_utils/parseRequestBody.ts
+++ b/pages/api/_utils/parseRequestBody.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest } from "next";
+
+export const parseRequestBody = <T>(body: NextApiRequest["body"]): T => {
+  if (body === undefined || body === null || body === "") {
+    return {} as T;
+  }
+
+  if (typeof body === "string") {
+    return JSON.parse(body) as T;
+  }
+
+  if (Buffer.isBuffer(body)) {
+    return JSON.parse(body.toString("utf8")) as T;
+  }
+
+  return body as T;
+};

--- a/pages/api/aave/bulk/index.ts
+++ b/pages/api/aave/bulk/index.ts
@@ -5,6 +5,7 @@ import {
   HealthFactorData,
   markets,
 } from "../../../../hooks/useAaveData";
+import { parseRequestBody } from "../../_utils/parseRequestBody";
 import { getAaveData } from "..";
 
 const allowedMethods = ["POST", "OPTIONS"];
@@ -18,15 +19,46 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
       return res.status(405).send({ message: "Method not allowed." });
     }
     const isAbbreviated = !!_req.query.abbreviated;
-    const { addresses } = JSON.parse(_req.body);
-    const { marketId } = JSON.parse(_req.body);
-    const market = markets.find(
-      (m: AaveMarketDataType) => m.id === marketId
-    ) as AaveMarketDataType;
+    const { addresses, marketId, blockNumber } = parseRequestBody<{
+      addresses?: string[];
+      marketId?: string;
+      blockNumber?: number;
+    }>(_req.body);
+
+    if (!Array.isArray(addresses) || addresses.length === 0 || !marketId) {
+      return res.status(400).json({
+        statusCode: 400,
+        message: "Addresses and marketId are required",
+      });
+    }
+
+    // Validate block number if provided
+    if (blockNumber !== undefined && blockNumber !== null) {
+      if (!Number.isInteger(blockNumber) || blockNumber < 0) {
+        return res.status(400).json({
+          statusCode: 400,
+          message: "Block number must be a non-negative integer",
+        });
+      }
+    }
+
+    const market = markets.find((m: AaveMarketDataType) => m.id === marketId);
+
+    if (!market) {
+      return res.status(400).json({
+        statusCode: 400,
+        message: `Market not found: ${marketId}`,
+      });
+    }
+
     const data = [];
 
     for (const address of addresses) {
-      const hf = (await getAaveData(address, market)) as HealthFactorData;
+      const hf = (await getAaveData(
+        address,
+        market,
+        blockNumber
+      )) as HealthFactorData;
       if (isAbbreviated && hf.workingData) hf.workingData.address = address; // we want the address included with abbrev. data (for generating test data fixtures)
       data.push(isAbbreviated ? hf.workingData : hf);
       await timer(500);

--- a/pages/api/aave/history/index.ts
+++ b/pages/api/aave/history/index.ts
@@ -1,5 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { AaveMarketDataType, markets, TxHistoryItem } from '../../../../hooks/useAaveData';
+import {
+  AaveMarketDataType,
+  markets,
+  TxHistoryItem,
+} from "../../../../hooks/useAaveData";
+import { parseRequestBody } from "../../_utils/parseRequestBody";
 
 const allowedMethods = ["POST", "OPTIONS"];
 
@@ -8,8 +13,17 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
     if (!allowedMethods.includes(_req.method!)) {
       return res.status(405).send({ message: "Method not allowed." });
     }
-    const { address } = JSON.parse(_req.body);
-    const { marketId } = JSON.parse(_req.body);
+    const { address, marketId } = parseRequestBody<{
+      address?: string;
+      marketId?: string;
+    }>(_req.body);
+
+    if (!address || !marketId) {
+      return res.status(400).json({
+        statusCode: 400,
+        message: "Address and marketId are required",
+      });
+    }
 
     const market = markets.find(
       (m: AaveMarketDataType) => m.id === marketId
@@ -21,7 +35,6 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
 
     const data: TxHistoryItem[] = await getTxData(address, market);
     res.status(200).json(data);
-
   } catch (err: any) {
     console.error(err);
     res.status(500).json({ statusCode: 500, message: err.message });
@@ -47,7 +60,7 @@ export const getTxData = async (address: string, market: AaveMarketDataType) => 
   }
 
   const data = await res.json();
-  return data.data.userTransactions || [];
+  return data?.data?.userTransactions || [];
 };
 
 export default handler;

--- a/pages/api/aave/index.ts
+++ b/pages/api/aave/index.ts
@@ -4,7 +4,7 @@ import {
   UiPoolDataProvider,
   UiPoolDataProviderContext,
   UiIncentiveDataProvider,
-  UiIncentiveDataProviderContext
+  UiIncentiveDataProviderContext,
 } from "@aave/contract-helpers";
 import dayjs from "dayjs";
 import {
@@ -26,6 +26,7 @@ import {
   getCalculatedLiquidationScenario,
   markets,
 } from "../../../hooks/useAaveData";
+import { parseRequestBody } from "../_utils/parseRequestBody";
 import { getResolvedAddress } from "../resolver";
 
 const allowedMethods = ["POST", "OPTIONS"];
@@ -36,13 +37,44 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
       return res.status(405).send({ message: "Method not allowed." });
     }
 
-    const { address } = JSON.parse(_req.body);
-    const { marketId } = JSON.parse(_req.body);
+    const { address, marketId, blockNumber } = parseRequestBody<{
+      address?: string;
+      marketId?: string;
+      blockNumber?: number;
+    }>(_req.body);
 
-    const market = markets.find(
-      (m: AaveMarketDataType) => m.id === marketId
-    ) as AaveMarketDataType;
-    const data: HealthFactorData = await getAaveData(address, market);
+    // Validate required parameters
+    if (!address || !marketId) {
+      return res.status(400).json({
+        statusCode: 400,
+        message: "Address and marketId are required",
+      });
+    }
+
+    // Validate block number if provided
+    if (blockNumber !== undefined && blockNumber !== null) {
+      if (!Number.isInteger(blockNumber) || blockNumber < 0) {
+        return res.status(400).json({
+          statusCode: 400,
+          message: "Block number must be a non-negative integer",
+        });
+      }
+    }
+
+    const market = markets.find((m: AaveMarketDataType) => m.id === marketId);
+
+    if (!market) {
+      return res.status(400).json({
+        statusCode: 400,
+        message: `Market not found: ${marketId}`,
+      });
+    }
+
+    const data: HealthFactorData = await getAaveData(
+      address,
+      market,
+      blockNumber
+    );
     res.status(200).json(data);
   } catch (err: any) {
     console.error(err);
@@ -50,45 +82,73 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export const getAaveData = async (address: string, market: AaveMarketDataType) => {
+export const getAaveData = async (
+  address: string,
+  market: AaveMarketDataType,
+  blockNumber?: number
+) => {
   const provider = new ethers.providers.StaticJsonRpcProvider(
     market.api,
     market.chainId
   );
+  const hasHistoricalBlock = blockNumber !== undefined && blockNumber !== null;
+
+  const effectiveProvider = hasHistoricalBlock
+    ? Object.assign(Object.create(provider), {
+        call: (
+          transaction: ethers.providers.TransactionRequest,
+          _blockTag?: ethers.providers.BlockTag
+        ) => provider.call(transaction, blockNumber),
+      })
+    : provider;
 
   const UiPoolDataCtx: UiPoolDataProviderContext = {
     uiPoolDataProviderAddress: market.addresses.UI_POOL_DATA_PROVIDER,
-    provider,
+    provider: effectiveProvider,
     chainId: market.chainId,
   };
   const poolDataProviderContract = new UiPoolDataProvider(UiPoolDataCtx);
 
   const UiIncentiveDataCtx: UiIncentiveDataProviderContext = {
     uiIncentiveDataProviderAddress: market.addresses.UI_INCENTIVE_DATA_PROVIDER,
-    provider,
+    provider: effectiveProvider,
     chainId: market.chainId,
   };
 
-  const incentiveDataProviderContract = new UiIncentiveDataProvider(UiIncentiveDataCtx);
+  const incentiveDataProviderContract = new UiIncentiveDataProvider(
+    UiIncentiveDataCtx
+  );
 
-  const user = (await getResolvedAddress(address)) || "0x87cCC67f0c1b67745989542152DD4acff3841CD6";
+  const user =
+    (await getResolvedAddress(address)) ||
+    "0x87cCC67f0c1b67745989542152DD4acff3841CD6";
 
-  const [reserves, userReserves, reserveIncentives, userIncentives] = await Promise.all([
-    poolDataProviderContract.getReservesHumanized({
-      lendingPoolAddressProvider: market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
-    }),
-    poolDataProviderContract.getUserReservesHumanized({
-      lendingPoolAddressProvider: market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
-      user
-    }),
-    incentiveDataProviderContract.getReservesIncentivesDataHumanized({
-      lendingPoolAddressProvider: market.addresses.LENDING_POOL_ADDRESS_PROVIDER
-    }),
-    incentiveDataProviderContract.getUserReservesIncentivesDataHumanized({
-      lendingPoolAddressProvider: market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
-      user
-    })
-  ]);
+  let currentBlockNumber = blockNumber;
+  if (!hasHistoricalBlock) {
+    currentBlockNumber = await provider.getBlockNumber();
+  }
+
+  const [reserves, userReserves, reserveIncentives, userIncentives] =
+    await Promise.all([
+      poolDataProviderContract.getReservesHumanized({
+        lendingPoolAddressProvider:
+          market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
+      }),
+      poolDataProviderContract.getUserReservesHumanized({
+        lendingPoolAddressProvider:
+          market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
+        user,
+      }),
+      incentiveDataProviderContract.getReservesIncentivesDataHumanized({
+        lendingPoolAddressProvider:
+          market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
+      }),
+      incentiveDataProviderContract.getUserReservesIncentivesDataHumanized({
+        lendingPoolAddressProvider:
+          market.addresses.LENDING_POOL_ADDRESS_PROVIDER,
+        user,
+      }),
+    ]);
 
   const reservesArray = reserves.reservesData;
   const { baseCurrencyData } = reserves;
@@ -103,7 +163,7 @@ export const getAaveData = async (address: string, market: AaveMarketDataType) =
       baseCurrencyData.marketReferenceCurrencyDecimals,
     marketReferencePriceInUsd:
       baseCurrencyData.marketReferenceCurrencyPriceInUsd,
-    reserveIncentives
+    reserveIncentives,
   });
 
   const userSummary = formatUserSummaryAndIncentives({
@@ -116,7 +176,7 @@ export const getAaveData = async (address: string, market: AaveMarketDataType) =
     formattedReserves: formattedPoolReserves,
     userEmodeCategoryId: userReserves.userEmodeCategoryId,
     reserveIncentives,
-    userIncentives
+    userIncentives,
   });
 
   const hf: HealthFactorData = aaveUserSummaryToHealthFactor(
@@ -125,7 +185,9 @@ export const getAaveData = async (address: string, market: AaveMarketDataType) =
     user, // if address is an ens, user will point to the resolved address.
     market,
     baseCurrencyData,
-    userReserves.userEmodeCategoryId
+    userReserves.userEmodeCategoryId,
+    hasHistoricalBlock ? currentBlockNumber : undefined,
+    currentBlockNumber
   );
   return hf;
 };
@@ -136,7 +198,9 @@ const aaveUserSummaryToHealthFactor = (
   resolvedAddress: string,
   market: AaveMarketDataType,
   baseCurrencyData: any,
-  userEmodeCategoryId: number
+  userEmodeCategoryId: number,
+  blockNumber?: number,
+  fetchedBlockNumber?: number
 ) => {
   const getAssetDetailsFromReserveItem = (reserveItem: ComputedUserReserve) => {
     const { reserve } = reserveItem;
@@ -152,9 +216,7 @@ const aaveUserSummaryToHealthFactor = (
       baseLTVasCollateral: Number(reserve.baseLTVasCollateral),
       reserveFactor: Number(reserve.reserveFactor),
       usageAsCollateralEnabled: reserve.usageAsCollateralEnabled,
-      reserveLiquidationThreshold: Number(
-        reserve.reserveLiquidationThreshold
-      ),
+      reserveLiquidationThreshold: Number(reserve.reserveLiquidationThreshold),
       initialPriceInUSD: Number(reserve.priceInUSD),
       aTokenAddress: reserve.aTokenAddress,
       stableDebtTokenAddress: reserve.stableDebtTokenAddress,
@@ -179,7 +241,7 @@ const aaveUserSummaryToHealthFactor = (
       eModeCategoryId: Number(reserve.eModeCategoryId),
       eModeLabel: reserve.eModeLabel,
       borrowableInIsolation: Boolean(reserve.borrowableInIsolation),
-      isSiloedBorrowing: Boolean(reserve.isSiloedBorrowing)
+      isSiloedBorrowing: Boolean(reserve.isSiloedBorrowing),
     };
     return details;
   };
@@ -261,7 +323,13 @@ const aaveUserSummaryToHealthFactor = (
     userReservesData: reserveData.userReservesData,
     userBorrowsData: reserveData.userBorrowsData,
     userEmodeCategoryId: reserveData.userEmodeCategoryId,
-    isInIsolationMode: reserveData.isInIsolationMode
+    isInIsolationMode: reserveData.isInIsolationMode,
+    txHistory: {
+      data: [],
+      isFetching: false,
+      fetchError: "",
+      lastFetched: 0,
+    },
   };
 
   const hf: HealthFactorData = {
@@ -277,12 +345,16 @@ const aaveUserSummaryToHealthFactor = (
     ),
     fetchedData,
     workingData: JSON.parse(JSON.stringify(fetchedData)),
+    selectedBlockNumber: blockNumber,
+    fetchedBlockNumber,
   };
   const liquidationScenario = getCalculatedLiquidationScenario(
     hf.workingData as AaveHealthFactorData,
     marketReferenceCurrencyPriceInUSD
   );
-  hf.workingData.liquidationScenario = liquidationScenario;
+  if (hf.workingData) {
+    (hf.workingData as any).liquidationScenario = liquidationScenario;
+  }
   return hf;
 };
 

--- a/pages/api/resolver/index.ts
+++ b/pages/api/resolver/index.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { ethers } from "ethers";
 
 import { Alchemy, Network } from "alchemy-sdk";
+import { parseRequestBody } from "../_utils/parseRequestBody";
 
 const allowedMethods = ["POST", "OPTIONS"];
 
@@ -11,7 +12,15 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
       return res.status(405).send({ message: "Method not allowed." });
     }
 
-    const { address } = JSON.parse(_req.body);
+    const { address } = parseRequestBody<{ address?: string }>(_req.body);
+
+    if (!address) {
+      return res.status(400).json({
+        statusCode: 400,
+        message: "Address is required",
+      });
+    }
+
     let resolvedAddress = address;
     if (!ethers.utils.isAddress(address)) {
       resolvedAddress =

--- a/store/healthFactorDataStore.ts
+++ b/store/healthFactorDataStore.ts
@@ -1,17 +1,22 @@
-import React from "react";
-import { hookstate, State } from "@hookstate/core";
-import { HealthFactorData } from "../hooks/useAaveData";
+import { hookstate } from "@hookstate/core";
+import type { HealthFactorData } from "../hooks/useAaveData";
 
 interface HealthFactorStore {
   currentAddress: string;
   currentMarket: string;
   addressData: Record<string, Record<string, HealthFactorData>>;
+  selectedBlockNumber?: number; // undefined means latest block
+  isHistoryMode: boolean; // true when viewing historical data
 }
 
-const defaultState: HealthFactorStore = {
+export const createDefaultHealthFactorStoreState = (): HealthFactorStore => ({
   currentAddress: "",
   currentMarket: "ETHEREUM_V3",
   addressData: {},
-};
+  selectedBlockNumber: undefined, // undefined means latest block
+  isHistoryMode: false,
+});
 
-export const HealthFactorDataStore: HealthFactorStore = hookstate(defaultState);
+export const HealthFactorDataStore: HealthFactorStore = hookstate(
+  createDefaultHealthFactorStoreState()
+);

--- a/test/hooks/useAaveData.test.ts
+++ b/test/hooks/useAaveData.test.ts
@@ -6,6 +6,10 @@ import {
   AaveHealthFactorData,
   getCalculatedLiquidationScenario,
 } from "../../hooks/useAaveData";
+import {
+  createDefaultHealthFactorStoreState,
+  HealthFactorDataStore,
+} from "../../store/healthFactorDataStore";
 import testDataItems from "../fixtures/aave/AaveHealthFactorData.json";
 import fetchMock from "jest-fetch-mock";
 
@@ -34,6 +38,7 @@ describe.each(testDataItems)(`useAaveData ()`, (testDataItem) => {
   if (!reserveDataItem) return;
 
   beforeEach(() => {
+    (HealthFactorDataStore as any).set(createDefaultHealthFactorStoreState());
     fetchMock.resetMocks();
     const testHF = getHFDataFromAaveDataSeed(testDataItem);
     fetchMock.mockResponse(JSON.stringify(testHF));
@@ -54,6 +59,39 @@ describe.each(testDataItems)(`useAaveData ()`, (testDataItem) => {
       expect(result.current.currentAddress).toEqual(testDataItem.address);
       expect(data.workingData).not.toBeUndefined();
       expect(fetch).toHaveBeenCalledTimes(markets.length);
+    });
+
+    test("it refetches the selected protocol when switching markets in history mode on the same chain", async () => {
+      const { result } = renderHook(() => useAaveData(testDataItem.address));
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledTimes(markets.length);
+      });
+
+      act(() => {
+        result.current.setSelectedBlockNumber(123);
+      });
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledTimes(markets.length + 1);
+      });
+
+      act(() => {
+        result.current.setCurrentMarket("ETHEREUM_V2");
+      });
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledTimes(markets.length + 2);
+      });
+
+      const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+      const body = JSON.parse(String(lastCall?.[1]?.body ?? "{}"));
+
+      expect(body).toMatchObject({
+        address: testDataItem.address,
+        marketId: "ETHEREUM_V2",
+        blockNumber: 123,
+      });
     });
 
     describe("when a supplied asset quantity is changed", () => {
@@ -149,7 +187,7 @@ describe.each(testDataItems)(`useAaveData ()`, (testDataItem) => {
           testDataItem.userReservesData.length === 1 &&
           testDataItem.userBorrowsData.length === 1 &&
           testDataItem.userReservesData[0].asset.symbol ===
-          testDataItem.userBorrowsData[0].asset.symbol
+            testDataItem.userBorrowsData[0].asset.symbol
         ) {
           expect(data.workingData?.healthFactor).toEqual(originalHealthFactor);
         } else {
@@ -276,12 +314,26 @@ describe.each(testDataItems)(`useAaveData ()`, (testDataItem) => {
   });
 });
 
-const getHFDataFromAaveDataSeed = (aaveData: AaveHealthFactorData) => {
+type AaveHealthFactorDataSeed = Omit<AaveHealthFactorData, "txHistory"> & {
+  txHistory?: AaveHealthFactorData["txHistory"];
+};
+
+const getHFDataFromAaveDataSeed = (aaveData: AaveHealthFactorDataSeed) => {
+  const dataWithHistory: AaveHealthFactorData = {
+    ...aaveData,
+    txHistory: aaveData.txHistory || {
+      data: [],
+      isFetching: false,
+      fetchError: "",
+      lastFetched: 0,
+    },
+  };
+
   return {
-    address: aaveData.address,
+    address: dataWithHistory.address,
     marketReferenceCurrencyPriceInUSD: 10000,
-    fetchedData: aaveData,
-    workingData: aaveData,
+    fetchedData: dataWithHistory,
+    workingData: dataWithHistory,
     lastFetched: Date.now(),
   };
 };


### PR DESCRIPTION
## Summary

This PR adds a history mode to DefiSim so users can inspect an Aave position at a specific block instead of only the latest state.

It introduces a block selector with direct block input, previous/next navigation, a quick return to latest, and a visible history-mode indicator. The selected block is then propagated through the app so the displayed position reflects that historical snapshot.

## Why

This makes DefiSim more useful for analyzing how a position changed over time, especially around volatile market conditions, liquidations, or major account actions. It turns the app into a more practical research and debugging tool for Aave users.

## Implementation Notes

This PR:
- adds block-based state handling across the frontend
- extends the Aave API flow to support optional historical block queries
- improves history-mode switching and loading behavior
- hardens request/error handling around API fetches
- updates related tests for the new history-mode behavior

Latest-mode behavior remains unchanged: when no block is selected, the app continues to show the most recent position state.

## Testing

Tested locally by:
- loading positions in normal latest mode
- switching to a historical block and verifying data updates
- navigating between blocks with the selector controls
- returning from history mode to latest mode
- verifying same-chain protocol switching behavior
