### PR TITLE
Add Interest Accrual Manifest page (/interest)

### DIFF
--- a/components/BorrowedAssetDetailsDialog.tsx
+++ b/components/BorrowedAssetDetailsDialog.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { t, Trans } from "@lingui/macro";
+import { useRouter } from "next/router";
 
 import {
+  Anchor,
   Button,
   Group,
   Modal,
@@ -44,6 +46,7 @@ export default function BorrowedAssetDetailsDialog({
   stableBorrowAPY,
 }: BorrowedAssetDetailsDialogProps) {
   const [open, setOpen] = React.useState(false);
+  const router = useRouter();
   const { addressData, currentMarket, currentAddress } = useAaveData("", true);
 
   const market = markets.find(
@@ -142,6 +145,20 @@ export default function BorrowedAssetDetailsDialog({
             }
           />
         </SimpleGrid>
+
+        <Space h="xs" />
+
+        <Group justify="center">
+          <Anchor
+            size="xs"
+            onClick={() => {
+              setOpen(false);
+              router.push(`/interest?address=${currentAddress}`);
+            }}
+          >
+            <Trans>View full interest history</Trans>
+          </Anchor>
+        </Group>
 
         <Divider
           label={t`Contract Information`}

--- a/components/InterestManifest.tsx
+++ b/components/InterestManifest.tsx
@@ -1,0 +1,598 @@
+import { useState } from "react";
+import { ethers } from "ethers";
+import { t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Button,
+  Center,
+  Divider,
+  Group,
+  Loader,
+  Paper,
+  Progress,
+  SegmentedControl,
+  Space,
+  Table,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { FaHistory } from "react-icons/fa";
+import { FiExternalLink, FiInfo, FiSearch } from "react-icons/fi";
+
+import {
+  AaveMarketDataType,
+  AssetDetails,
+  markets,
+  useAaveData,
+} from "../hooks/useAaveData";
+import {
+  useAccrualLedger,
+  useAccrualManifest,
+} from "../hooks/useAccrualLedger";
+import {
+  AccrualSide,
+  LedgerRow,
+  ManifestAssetRef,
+} from "../pages/api/aave/accrual";
+import { LedgerAction } from "../utils/tokenEventAccrual";
+import { formatTokenAmount } from "../utils/formatTokenAmount";
+import LocalizedFiatDisplay from "./LocalizedFiatDisplay";
+import TokenIcon from "./TokenIcon";
+import { AbbreviatedEthereumAddress } from "./position/AbbreviatedEthereumAddress";
+
+type SideFilter = "ALL" | "SUPPLY" | "BORROW";
+
+type ManifestPosition = {
+  asset: AssetDetails;
+  side: AccrualSide;
+  tokenAddress: string;
+  isOpen: boolean;
+};
+
+const getActionLabel = (action: LedgerAction): string => {
+  switch (action) {
+    case "Supply":
+      return t`Supply`;
+    case "Withdraw":
+      return t`Withdraw`;
+    case "Borrow":
+      return t`Borrow`;
+    case "Repay":
+      return t`Repay`;
+    case "TransferIn":
+      return t`Transfer in`;
+    case "TransferOut":
+      return t`Transfer out`;
+    case "InterestApplied":
+    default:
+      return t`Interest applied`;
+  }
+};
+
+/** Markets link addresses as `.../address/{{ADDRESS}}`; tx pages swap the path segment */
+const getExplorerTxUrl = (market: AaveMarketDataType, txHash: string): string =>
+  market.explorer.replace("/address/", "/tx/").replace("{{ADDRESS}}", txHash);
+
+const matchesFilters = (
+  position: ManifestPosition,
+  sideFilter: SideFilter,
+  searchText: string
+): boolean => {
+  if (sideFilter === "SUPPLY" && position.side !== "supply") return false;
+  if (sideFilter === "BORROW" && position.side !== "borrow") return false;
+  if (!searchText.length) return true;
+  return (
+    position.asset.name?.toUpperCase().includes(searchText.toUpperCase()) ||
+    position.asset.symbol?.toUpperCase().includes(searchText.toUpperCase())
+  );
+};
+
+export default function InterestManifest() {
+  const { addressData, currentMarket, currentAddress } = useAaveData("", true);
+  const [sideFilter, setSideFilter] = useState<SideFilter>("ALL");
+  const [searchText, setSearchText] = useState("");
+
+  const marketData = addressData?.[currentMarket];
+  const market = markets.find(
+    (m) => m.id === currentMarket
+  ) as AaveMarketDataType;
+  const resolvedAddress: string = marketData?.resolvedAddress ?? "";
+  const manifest = useAccrualManifest(currentMarket, resolvedAddress);
+
+  if (!market) return null;
+
+  if (marketData?.isFetching) {
+    return (
+      <Center mt={50} mb={50}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (!ethers.utils.isAddress(resolvedAddress)) {
+    return (
+      <Alert icon={<FiInfo size="1rem" />} color="blue" mt={20}>
+        <Trans>
+          Interest history is reconstructed from on-chain events, so it is only
+          available for real on-chain addresses (not simulated sandbox
+          positions).
+        </Trans>
+      </Alert>
+    );
+  }
+
+  // The manifest reflects the real on-chain position (fetchedData), never
+  // simulated edits, so accrual history always matches the chain.
+  const openPositions: ManifestPosition[] = [];
+  marketData?.fetchedData?.userReservesData?.forEach((item) => {
+    if (!item.asset.aTokenAddress) return;
+    openPositions.push({
+      asset: item.asset,
+      side: "supply",
+      tokenAddress: item.asset.aTokenAddress,
+      isOpen: true,
+    });
+  });
+  marketData?.fetchedData?.userBorrowsData?.forEach((item) => {
+    if (!item.asset.variableDebtTokenAddress) return;
+    openPositions.push({
+      asset: item.asset,
+      side: "borrow",
+      tokenAddress: item.asset.variableDebtTokenAddress,
+      isOpen: true,
+    });
+  });
+
+  const openTokenAddresses = new Set(
+    openPositions.map((position) => position.tokenAddress.toLowerCase())
+  );
+
+  // Closed positions discovered by the full-history scan: any scanned token
+  // with at least one event that isn't part of the current position.
+  const closedPositions: ManifestPosition[] = (manifest.results ?? [])
+    .filter(
+      (item) =>
+        (item.data?.eventCount ?? 0) > 0 &&
+        !openTokenAddresses.has(item.tokenAddress.toLowerCase())
+    )
+    .map((item) => {
+      const asset = marketData?.availableAssets?.find(
+        (a) => a.symbol === item.symbol
+      );
+      if (!asset) return null;
+      return {
+        asset,
+        side: item.side,
+        tokenAddress: item.tokenAddress,
+        isOpen: false,
+      };
+    })
+    .filter((position): position is ManifestPosition => !!position)
+    .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol));
+
+  const filteredOpen = openPositions.filter((position) =>
+    matchesFilters(position, sideFilter, searchText)
+  );
+  const filteredClosed = closedPositions.filter((position) =>
+    matchesFilters(position, sideFilter, searchText)
+  );
+
+  // Sides already shown as open positions don't need to be scanned again
+  const scanRefs: ManifestAssetRef[] = (marketData?.availableAssets ?? [])
+    .map((asset) => ({
+      symbol: asset.symbol,
+      aTokenAddress:
+        asset.aTokenAddress &&
+        !openTokenAddresses.has(asset.aTokenAddress.toLowerCase())
+          ? asset.aTokenAddress
+          : undefined,
+      variableDebtTokenAddress:
+        asset.variableDebtTokenAddress &&
+        !openTokenAddresses.has(asset.variableDebtTokenAddress.toLowerCase())
+          ? asset.variableDebtTokenAddress
+          : undefined,
+    }))
+    .filter((ref) => ref.aTokenAddress || ref.variableDebtTokenAddress);
+
+  return (
+    <>
+      <Group justify="space-between" mt={10} mb={5}>
+        <Title order={4}>
+          <Trans>Interest Accrual History</Trans>
+        </Title>
+        <Text size="sm" c="dimmed">
+          <AbbreviatedEthereumAddress address={currentAddress} />
+          {" · "}
+          {market.title}
+        </Text>
+      </Group>
+
+      <Alert
+        icon={<FiInfo size="1rem" />}
+        color="blue"
+        variant="outline"
+        mb={15}
+      >
+        <Trans>
+          This accounting is reconstructed from on-chain aToken and variable
+          debt token events, so every row corresponds to a real transaction.
+          Interest is credited to your balance whenever you interact with a
+          reserve; the remainder accrues continuously since your last activity.
+          Fiat values use current prices (historical prices are not available).
+          This feature is experimental.
+        </Trans>
+      </Alert>
+
+      <Group justify="space-between" mb={15}>
+        <SegmentedControl
+          size="xs"
+          value={sideFilter}
+          onChange={(value) => setSideFilter(value as SideFilter)}
+          data={[
+            { label: t`All`, value: "ALL" },
+            { label: t`Supplied`, value: "SUPPLY" },
+            { label: t`Borrowed`, value: "BORROW" },
+          ]}
+        />
+        <TextInput
+          size="xs"
+          leftSection={<FiSearch />}
+          placeholder={t`Filter by asset`}
+          value={searchText}
+          onChange={(event) => setSearchText(event.currentTarget.value)}
+        />
+      </Group>
+
+      {filteredOpen.length === 0 && filteredClosed.length === 0 && (
+        <Center mt={30} mb={30}>
+          <Text c="dimmed">
+            {openPositions.length === 0 ? (
+              <Trans>
+                No supplied or borrowed assets found for this address in this
+                market.
+              </Trans>
+            ) : (
+              <Trans>No assets match the current filters.</Trans>
+            )}
+          </Text>
+        </Center>
+      )}
+
+      {filteredOpen.map((position) => (
+        <AssetLedgerSection
+          key={`${position.tokenAddress}:${position.side}`}
+          position={position}
+          market={market}
+          user={resolvedAddress}
+        />
+      ))}
+
+      {filteredClosed.length > 0 && (
+        <>
+          <Divider
+            label={t`Previously held positions`}
+            labelPosition="center"
+            mt={25}
+            mb={15}
+          />
+          {filteredClosed.map((position) => (
+            <AssetLedgerSection
+              key={`${position.tokenAddress}:${position.side}`}
+              position={position}
+              market={market}
+              user={resolvedAddress}
+            />
+          ))}
+        </>
+      )}
+
+      <Space h="lg" />
+
+      <ManifestScanSection
+        manifest={manifest}
+        scanRefs={scanRefs}
+        closedCount={closedPositions.length}
+      />
+    </>
+  );
+}
+
+type ManifestScanSectionProps = {
+  manifest: ReturnType<typeof useAccrualManifest>;
+  scanRefs: ManifestAssetRef[];
+  closedCount: number;
+};
+
+const ManifestScanSection = ({
+  manifest,
+  scanRefs,
+  closedCount,
+}: ManifestScanSectionProps) => {
+  const { isScanning, scanError, progress, results, startScan } = manifest;
+
+  return (
+    <>
+      <Divider label={t`Full History`} labelPosition="center" mb={15} />
+
+      {!results && !isScanning && (
+        <Center>
+          <div style={{ textAlign: "center" }}>
+            <Text size="sm" c="dimmed" mb={10}>
+              <Trans>
+                Scan every reserve in this market to find interest accrued by
+                positions that were closed in the past. This checks each token
+                contract for your activity and may take a minute.
+              </Trans>
+            </Text>
+            <Button
+              leftSection={<FaHistory size={14} />}
+              variant="outline"
+              onClick={() => startScan(scanRefs)}
+              disabled={!scanRefs.length}
+            >
+              <Trans>Scan Full History</Trans>
+            </Button>
+          </div>
+        </Center>
+      )}
+
+      {isScanning && (
+        <>
+          <Progress
+            value={progress.total ? (progress.done / progress.total) * 100 : 0}
+            animated
+            mb={10}
+          />
+          <Center>
+            <Text size="sm" c="dimmed">
+              <Trans>
+                Scanning token contracts: {progress.done} of {progress.total}
+              </Trans>
+            </Text>
+          </Center>
+        </>
+      )}
+
+      {!!scanError.length && (
+        <Center>
+          <Text size="sm" c="red">
+            <Trans>The full history scan failed: {scanError}</Trans>
+          </Text>
+        </Center>
+      )}
+
+      {results && !isScanning && (
+        <Center>
+          <Text size="sm" c="dimmed">
+            {closedCount > 0 ? (
+              <Trans>
+                Scan complete: found {closedCount} previously held asset
+                positions with interest history.
+              </Trans>
+            ) : (
+              <Trans>
+                Scan complete: no additional assets with interest history were
+                found.
+              </Trans>
+            )}
+          </Text>
+        </Center>
+      )}
+    </>
+  );
+};
+
+type AssetLedgerSectionProps = {
+  position: ManifestPosition;
+  market: AaveMarketDataType;
+  user: string;
+};
+
+const AssetLedgerSection = ({
+  position,
+  market,
+  user,
+}: AssetLedgerSectionProps) => {
+  const { i18n } = useLingui();
+  const { isFetching, fetchError, data } = useAccrualLedger(
+    market.id,
+    user,
+    position.tokenAddress,
+    position.side
+  );
+
+  const { asset, side, isOpen } = position;
+  const { symbol } = asset;
+
+  const accrued = Number(data?.accruedValue ?? "0");
+  const pending = Number(data?.pendingValue ?? "0");
+  const realized = Number(data?.realizedValue ?? "0");
+
+  // The accrual math over token events is exact, so a negative value indicates a
+  // token with non-standard accounting (e.g. GHO's discounted debt) or an RPC
+  // inconsistency; hide the values rather than display wrong numbers.
+  const isInvalidValue: boolean =
+    !!fetchError?.length ||
+    (!isFetching &&
+      (data?.accruedValue === undefined || accrued < 0 || pending < 0));
+
+  const formatAmount = (value: number): string =>
+    formatTokenAmount(value, i18n.locale);
+
+  const signedAmount = (value: number): string => {
+    if (value === 0) return "—";
+    const sign = value > 0 ? "+" : "−";
+    return `${sign}${formatAmount(Math.abs(value))}`;
+  };
+
+  const formatDate = (timestamp: number | null): string =>
+    timestamp
+      ? i18n.date(new Date(timestamp * 1000), {
+          dateStyle: "medium",
+          timeStyle: "short",
+        })
+      : "—";
+
+  return (
+    <Paper withBorder p="md" mb="md">
+      <Group justify="space-between" mb={5}>
+        <Group gap={8}>
+          <TokenIcon symbol={symbol} size="22px" />
+          <Text fw={700}>{symbol}</Text>
+          {side === "supply" ? (
+            <Badge color="blue" radius="sm" variant="light">
+              <Trans>Supplied</Trans>
+            </Badge>
+          ) : (
+            <Badge color="orange" radius="sm" variant="light">
+              <Trans>Borrowed</Trans>
+            </Badge>
+          )}
+          {!isOpen && (
+            <Badge color="gray" radius="sm" variant="outline">
+              <Trans>Closed</Trans>
+            </Badge>
+          )}
+        </Group>
+        {isFetching ? (
+          <Loader type="dots" />
+        ) : isInvalidValue ? (
+          <Text size="sm" c="dimmed">
+            <Trans>Unavailable</Trans>
+          </Text>
+        ) : (
+          <Text size="sm" fw={600}>
+            {`${formatAmount(accrued)} ${symbol} `}
+            (<LocalizedFiatDisplay valueUSD={accrued * asset.priceInUSD} />)
+          </Text>
+        )}
+      </Group>
+
+      {isFetching && (
+        <Text size="xs" c="dimmed">
+          <Trans>Loading on-chain interest history...</Trans>
+        </Text>
+      )}
+
+      {!isFetching && isInvalidValue && (
+        <Text size="xs" c="dimmed">
+          <Trans>
+            The interest history for this asset cannot be displayed. The token
+            may use non-standard accounting (e.g. GHO), or the event data could
+            not be fetched.
+          </Trans>
+        </Text>
+      )}
+
+      {!isFetching && !isInvalidValue && data && (
+        <>
+          <Text size="xs" c="dimmed" mb={10}>
+            {side === "supply" ? (
+              <Trans>
+                Total interest earned over the life of this position, of which{" "}
+                {formatAmount(realized)} {symbol} was credited during past
+                activity and {formatAmount(pending)} {symbol} has accrued since
+                the last activity.
+              </Trans>
+            ) : (
+              <Trans>
+                Total interest owed over the life of this position, of which{" "}
+                {formatAmount(realized)} {symbol} was applied during past
+                activity and {formatAmount(pending)} {symbol} has accrued since
+                the last activity.
+              </Trans>
+            )}
+          </Text>
+
+          {data.ledger?.length ? (
+            <div style={{ overflowX: "auto" }}>
+              <Table fz="xs" striped highlightOnHover>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>
+                      <Trans>Date</Trans>
+                    </Table.Th>
+                    <Table.Th>
+                      <Trans>Action</Trans>
+                    </Table.Th>
+                    <Table.Th ta="right">
+                      <Trans>Amount</Trans>
+                    </Table.Th>
+                    <Table.Th ta="right">
+                      <Trans>Interest Accrued</Trans>
+                    </Table.Th>
+                    <Table.Th>
+                      <Trans>Tx</Trans>
+                    </Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {data.ledger.map((row: LedgerRow, index: number) => {
+                    const principal = Number(row.principalDelta);
+                    const interest = Number(row.interestRealized);
+                    return (
+                      <Table.Tr key={`${row.blockNumber}-${index}`}>
+                        <Table.Td style={{ whiteSpace: "nowrap" }}>
+                          {formatDate(row.timestamp)}
+                        </Table.Td>
+                        <Table.Td>{getActionLabel(row.action)}</Table.Td>
+                        <Table.Td ta="right" style={{ whiteSpace: "nowrap" }}>
+                          {signedAmount(principal)}
+                        </Table.Td>
+                        <Table.Td ta="right" style={{ whiteSpace: "nowrap" }}>
+                          {interest > 0 ? formatAmount(interest) : "—"}
+                        </Table.Td>
+                        <Table.Td>
+                          {row.txHash && (
+                            <Anchor
+                              href={getExplorerTxUrl(market, row.txHash)}
+                              target="_blank"
+                              rel="noreferrer"
+                              title={t`View transaction on ${market.explorerName}`}
+                              c="dimmed"
+                            >
+                              <FiExternalLink />
+                            </Anchor>
+                          )}
+                        </Table.Td>
+                      </Table.Tr>
+                    );
+                  })}
+                  {pending > 0 && (
+                    <Table.Tr>
+                      <Table.Td>
+                        <Text c="dimmed" fs="italic" span size="xs">
+                          <Trans>Now</Trans>
+                        </Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text c="dimmed" fs="italic" span size="xs">
+                          <Trans>Accruing since last activity</Trans>
+                        </Text>
+                      </Table.Td>
+                      <Table.Td ta="right">—</Table.Td>
+                      <Table.Td ta="right" style={{ whiteSpace: "nowrap" }}>
+                        <Text c="dimmed" fs="italic" span size="xs">
+                          {formatAmount(pending)}
+                        </Text>
+                      </Table.Td>
+                      <Table.Td />
+                    </Table.Tr>
+                  )}
+                </Table.Tbody>
+              </Table>
+            </div>
+          ) : (
+            <Text size="xs" c="dimmed">
+              <Trans>No on-chain events found for this asset.</Trans>
+            </Text>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+};

--- a/components/ReserveAssetDetailsDialog.tsx
+++ b/components/ReserveAssetDetailsDialog.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { t, Trans } from "@lingui/macro";
+import { useRouter } from "next/router";
 
 import {
+  Anchor,
   Button,
   Group,
   Modal,
@@ -40,6 +42,7 @@ export default function ReserveAssetDetailsDialog({
   assetDetails,
 }: ReserveAssetDetailsDialogProps) {
   const [open, setOpen] = React.useState(false);
+  const router = useRouter();
   const { addressData, currentMarket, currentAddress } = useAaveData("", true);
 
   const market = markets.find(
@@ -131,6 +134,20 @@ export default function ReserveAssetDetailsDialog({
             }
           />
         </SimpleGrid>
+
+        <Space h="xs" />
+
+        <Group justify="center">
+          <Anchor
+            size="xs"
+            onClick={() => {
+              setOpen(false);
+              router.push(`/interest?address=${currentAddress}`);
+            }}
+          >
+            <Trans>View full interest history</Trans>
+          </Anchor>
+        </Group>
 
         <Divider
           label={t`Contract Information`}

--- a/hooks/useAccrualLedger.ts
+++ b/hooks/useAccrualLedger.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  AccrualResponse,
+  AccrualSide,
+  ManifestAssetRef,
+  ManifestScanItem,
+  getAccrualData,
+  getAccrualManifest,
+} from "../pages/api/aave/accrual";
+import { markets } from "./useAaveData";
+
+export type AccrualLedgerState = {
+  isFetching: boolean;
+  fetchError: string;
+  /** full accrual data including the chronological event ledger */
+  data?: AccrualResponse;
+};
+
+const PENDING: AccrualLedgerState = { isFetching: true, fetchError: "" };
+
+// results are immutable for a given (market, token, user) within a session,
+// so cache them to avoid refetching when navigating around
+const ledgerCache = new Map<string, AccrualLedgerState>();
+
+const ledgerCacheKey = (
+  marketId: string | undefined,
+  tokenAddress: string | undefined,
+  user: string | undefined,
+  side: AccrualSide
+) => `${marketId}:${tokenAddress}:${user}:${side}`.toLowerCase();
+
+/**
+ * Fetch the full interest accrual ledger (every classified, dated event) for
+ * one position from on-chain token events. Same cache pattern as
+ * useAccruedInterest, but includes per-event detail.
+ */
+export function useAccrualLedger(
+  marketId: string | undefined,
+  user: string | undefined,
+  tokenAddress: string | undefined,
+  side: AccrualSide
+) {
+  const isReady: boolean =
+    !!marketId?.length && !!user?.length && !!tokenAddress?.length;
+  const key = ledgerCacheKey(marketId, tokenAddress, user, side);
+  const [state, setState] = useState<AccrualLedgerState>(
+    ledgerCache.get(key) ?? PENDING
+  );
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    const cached = ledgerCache.get(key);
+    if (cached) {
+      setState(cached);
+      if (cached.isFetching === false) return;
+    }
+    if (cached?.isFetching) return; // another component instance is already fetching
+
+    let cancelled = false;
+    ledgerCache.set(key, PENDING);
+    setState(PENDING);
+
+    const fetchData = async () => {
+      let next: AccrualLedgerState;
+      try {
+        // Fetched directly from the browser (like getAaveData) so RPC requests
+        // carry the page origin; keyed RPC providers may allowlist origins and
+        // reject server-side requests that have none.
+        const market = markets.find((m) => m.id === marketId);
+        if (!market) throw new Error(`Unknown market: ${marketId}`);
+        const data = await getAccrualData(
+          market,
+          user!,
+          tokenAddress!,
+          side,
+          true
+        );
+        next = { isFetching: false, fetchError: "", data };
+      } catch (err: any) {
+        next = {
+          isFetching: false,
+          fetchError: err?.message ?? "Failed to fetch",
+        };
+      }
+      ledgerCache.set(key, next);
+      if (!cancelled) setState(next);
+    };
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [key, isReady]);
+
+  return isReady ? state : PENDING;
+}
+
+export type ManifestScanState = {
+  isScanning: boolean;
+  scanError: string;
+  progress: { done: number; total: number };
+  /** all scanned (token, side) results; present once a scan has completed */
+  results?: ManifestScanItem[];
+};
+
+const IDLE: ManifestScanState = {
+  isScanning: false,
+  scanError: "",
+  progress: { done: 0, total: 0 },
+};
+
+// one full-history scan result per (market, user) within a session
+const manifestCache = new Map<string, ManifestScanState>();
+
+/**
+ * On-demand full-history scan across all reserves of a market: finds every
+ * asset (including long-closed positions) where this user ever accrued
+ * interest, on the supply or variable-borrow side.
+ */
+export function useAccrualManifest(
+  marketId: string | undefined,
+  user: string | undefined
+) {
+  const key = `${marketId}:${user}`.toLowerCase();
+  const [state, setState] = useState<ManifestScanState>(
+    manifestCache.get(key) ?? IDLE
+  );
+
+  useEffect(() => {
+    setState(manifestCache.get(key) ?? IDLE);
+  }, [key]);
+
+  const startScan = useCallback(
+    (assets: ManifestAssetRef[]) => {
+      if (!marketId?.length || !user?.length) return;
+      const existing = manifestCache.get(key);
+      if (existing?.isScanning || existing?.results) return;
+
+      const market = markets.find((m) => m.id === marketId);
+      if (!market) return;
+
+      const update = (next: ManifestScanState) => {
+        manifestCache.set(key, next);
+        setState(next);
+      };
+
+      update({ ...IDLE, isScanning: true });
+
+      const scan = async () => {
+        try {
+          const results = await getAccrualManifest(
+            market,
+            user,
+            assets,
+            (done, total) =>
+              update({
+                isScanning: true,
+                scanError: "",
+                progress: { done, total },
+                results: undefined,
+              })
+          );
+          // seed the per-position ledger cache so asset sections render
+          // scan results without refetching
+          results.forEach((item) => {
+            if (!item.data) return;
+            ledgerCache.set(
+              ledgerCacheKey(marketId, item.tokenAddress, user, item.side),
+              { isFetching: false, fetchError: "", data: item.data }
+            );
+          });
+          update({
+            isScanning: false,
+            scanError: "",
+            progress: { done: results.length, total: results.length },
+            results,
+          });
+        } catch (err: any) {
+          update({ ...IDLE, scanError: err?.message ?? "Scan failed" });
+        }
+      };
+
+      scan();
+    },
+    [key, marketId, user]
+  );
+
+  return { ...state, startScan };
+}

--- a/pages/api/aave/accrual/index.ts
+++ b/pages/api/aave/accrual/index.ts
@@ -4,10 +4,15 @@ import { formatUnits } from "ethers/lib/utils";
 
 import { AaveMarketDataType, markets } from "../../../../hooks/useAaveData";
 import {
+  AccrualSide,
+  LedgerAction,
   TokenFlowEvent,
+  buildLedger,
   clampRoundingDust,
   findFirstPrincipalEvent,
   getAccruedInterest,
+  getPendingInterest,
+  getRealizedInterest,
 } from "../../../../utils/tokenEventAccrual";
 
 const TOKEN_ABI = [
@@ -18,7 +23,7 @@ const TOKEN_ABI = [
   "function decimals() view returns (uint8)",
 ];
 
-export type AccrualSide = "supply" | "borrow";
+export type { AccrualSide };
 
 /** Alchemy (and similar providers) reject eth_getLogs responses above ~10k logs */
 const LOG_CAP_ERROR =
@@ -63,6 +68,19 @@ export const getLogsChunked = async (
   }
 };
 
+/** One classified, dated event of the position's interest accounting */
+export type LedgerRow = {
+  action: LedgerAction;
+  /** signed principal change in human-readable token units */
+  principalDelta: string;
+  /** interest credited to the balance at this event, human-readable units */
+  interestRealized: string;
+  /** unix seconds of the event's block */
+  timestamp: number | null;
+  txHash: string | null;
+  blockNumber: number;
+};
+
 export type AccrualResponse = {
   /** accrued interest in human-readable token units */
   accruedValue: string;
@@ -72,6 +90,40 @@ export type AccrualResponse = {
   sinceTimestamp: number | null;
   /** number of balance-changing events found for this user/token */
   eventCount: number;
+  /** chronological event ledger; present when includeLedger was requested */
+  ledger?: LedgerRow[];
+  /** interest credited to the balance at past events, human-readable units */
+  realizedValue?: string;
+  /** interest accrued since the last event, human-readable units */
+  pendingValue?: string;
+};
+
+/**
+ * Resolve block timestamps for the given block numbers with a bounded number
+ * of concurrent RPC requests. Positions rarely span more than a few dozen
+ * unique blocks, so this stays cheap.
+ */
+const resolveBlockTimestamps = async (
+  provider: ethers.providers.StaticJsonRpcProvider,
+  blockNumbers: number[],
+  concurrency: number = 8
+): Promise<Map<number, number>> => {
+  const unique = [...new Set(blockNumbers)];
+  const timestamps = new Map<number, number>();
+  let next = 0;
+  const worker = async () => {
+    while (next < unique.length) {
+      const blockNumber = unique[next];
+      next += 1;
+      // eslint-disable-next-line no-await-in-loop
+      const block = await provider.getBlock(blockNumber);
+      timestamps.set(blockNumber, block.timestamp);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, unique.length) }, worker)
+  );
+  return timestamps;
 };
 
 const allowedMethods = ["POST", "OPTIONS"];
@@ -84,11 +136,12 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
     }
     const body =
       typeof _req.body === "string" ? JSON.parse(_req.body) : _req.body;
-    const { marketId, user, tokenAddress, side } = body as {
+    const { marketId, user, tokenAddress, side, includeLedger } = body as {
       marketId: string;
       user: string;
       tokenAddress: string;
       side: AccrualSide;
+      includeLedger?: boolean;
     };
 
     const market = markets.find((m: AaveMarketDataType) => m.id === marketId);
@@ -107,7 +160,8 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
       market,
       user,
       tokenAddress,
-      side
+      side,
+      !!includeLedger
     );
     res.status(200).json(data);
   } catch (err: any) {
@@ -120,7 +174,8 @@ export const getAccrualData = async (
   market: AaveMarketDataType,
   user: string,
   tokenAddress: string,
-  side: AccrualSide
+  side: AccrualSide,
+  includeLedger: boolean = false
 ): Promise<AccrualResponse> => {
   const provider = new ethers.providers.StaticJsonRpcProvider(
     market.api,
@@ -167,6 +222,7 @@ export const getAccrualData = async (
       balanceIncrease: args.balanceIncrease.toString(),
       blockNumber: log.blockNumber,
       logIndex: log.logIndex,
+      transactionHash: log.transactionHash,
     });
   });
 
@@ -178,6 +234,7 @@ export const getAccrualData = async (
       balanceIncrease: args.balanceIncrease.toString(),
       blockNumber: log.blockNumber,
       logIndex: log.logIndex,
+      transactionHash: log.transactionHash,
     });
   });
 
@@ -191,6 +248,7 @@ export const getAccrualData = async (
       value: args.value.toString(),
       blockNumber: log.blockNumber,
       logIndex: log.logIndex,
+      transactionHash: log.transactionHash,
     });
   });
 
@@ -202,6 +260,7 @@ export const getAccrualData = async (
       value: args.value.toString(),
       blockNumber: log.blockNumber,
       logIndex: log.logIndex,
+      transactionHash: log.transactionHash,
     });
   });
 
@@ -211,16 +270,129 @@ export const getAccrualData = async (
   );
 
   const firstPrincipalEvent = findFirstPrincipalEvent(events);
-  const sinceTimestamp = firstPrincipalEvent
-    ? (await provider.getBlock(firstPrincipalEvent.blockNumber)).timestamp
-    : null;
+
+  if (!includeLedger) {
+    const sinceTimestamp = firstPrincipalEvent
+      ? (await provider.getBlock(firstPrincipalEvent.blockNumber)).timestamp
+      : null;
+
+    return {
+      accruedValue: formatUnits(accruedRaw, decimals),
+      accruedRaw: accruedRaw.toString(),
+      sinceTimestamp,
+      eventCount: events.length,
+    };
+  }
+
+  const timestamps = await resolveBlockTimestamps(
+    provider,
+    events.map((event) => event.blockNumber)
+  );
+  events.forEach((event) => {
+    // eslint-disable-next-line no-param-reassign
+    event.timestamp = timestamps.get(event.blockNumber);
+  });
+
+  const ledger: LedgerRow[] = buildLedger(events, side).map((entry) => ({
+    action: entry.action,
+    principalDelta: formatUnits(entry.principalDelta, decimals),
+    interestRealized: formatUnits(entry.interestRealized, decimals),
+    timestamp: entry.timestamp ?? null,
+    txHash: entry.transactionHash ?? null,
+    blockNumber: entry.blockNumber,
+  }));
+
+  const pendingRaw = clampRoundingDust(
+    getPendingInterest(balance.toString(), events),
+    events.length
+  );
 
   return {
     accruedValue: formatUnits(accruedRaw, decimals),
     accruedRaw: accruedRaw.toString(),
-    sinceTimestamp,
+    sinceTimestamp: firstPrincipalEvent
+      ? timestamps.get(firstPrincipalEvent.blockNumber) ?? null
+      : null,
     eventCount: events.length,
+    ledger,
+    realizedValue: formatUnits(getRealizedInterest(events), decimals),
+    pendingValue: formatUnits(pendingRaw, decimals),
   };
+};
+
+/** A reserve's user-facing identity plus the token contracts to scan */
+export type ManifestAssetRef = {
+  symbol: string;
+  aTokenAddress?: string;
+  variableDebtTokenAddress?: string;
+};
+
+export type ManifestScanItem = {
+  symbol: string;
+  side: AccrualSide;
+  tokenAddress: string;
+  data?: AccrualResponse;
+  error?: string;
+};
+
+/**
+ * Scan every provided reserve (supply and variable-borrow side) for this
+ * user's complete interest history, including positions that were closed long
+ * ago. Runs up to `concurrency` token scans at a time; each token scan is
+ * itself a handful of RPC calls, so keep this modest.
+ */
+export const getAccrualManifest = async (
+  market: AaveMarketDataType,
+  user: string,
+  assets: ManifestAssetRef[],
+  onProgress?: (done: number, total: number) => void,
+  concurrency: number = 4
+): Promise<ManifestScanItem[]> => {
+  const tasks: ManifestScanItem[] = [];
+  assets.forEach((asset) => {
+    if (asset.aTokenAddress) {
+      tasks.push({
+        symbol: asset.symbol,
+        side: "supply",
+        tokenAddress: asset.aTokenAddress,
+      });
+    }
+    if (asset.variableDebtTokenAddress) {
+      tasks.push({
+        symbol: asset.symbol,
+        side: "borrow",
+        tokenAddress: asset.variableDebtTokenAddress,
+      });
+    }
+  });
+
+  let next = 0;
+  let done = 0;
+  const worker = async () => {
+    while (next < tasks.length) {
+      const task = tasks[next];
+      next += 1;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        task.data = await getAccrualData(
+          market,
+          user,
+          task.tokenAddress,
+          task.side,
+          true
+        );
+      } catch (err: any) {
+        task.error = err?.message ?? "Failed to fetch";
+      }
+      done += 1;
+      onProgress?.(done, tasks.length);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, tasks.length) }, worker)
+  );
+
+  return tasks;
 };
 
 export default handler;

--- a/pages/interest.tsx
+++ b/pages/interest.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import { Button, Center, Container, Space, Text } from "@mantine/core";
+import { NextRouter, useRouter } from "next/router";
+import { ethers } from "ethers";
+import { Trans } from "@lingui/macro";
+
+import { useAaveData } from "../hooks/useAaveData";
+import AppBar from "../components/AppBar";
+import { isValidENSAddress } from "../components/AddressInput";
+import InterestManifest from "../components/InterestManifest";
+import Footer from "../components/Footer";
+import { activateLocale } from "./_app";
+
+export default function InterestPage() {
+  const router: NextRouter = useRouter();
+  const address = router?.query?.address as string;
+  const isValidAddress: boolean =
+    ethers.utils.isAddress(address) || isValidENSAddress(address);
+  const { currentAddress, setCurrentAddress } = useAaveData(
+    isValidAddress ? address : ""
+  );
+
+  const locale = router?.locale;
+
+  useEffect(() => {
+    // ensure current address is correctly set from url
+    if (!address && currentAddress) {
+      setCurrentAddress("");
+    }
+    if (router.query.address && router.query.address !== currentAddress) {
+      if (isValidAddress) {
+        setCurrentAddress(address);
+      }
+    }
+  }, [address]);
+
+  useEffect(() => {
+    // ensure current locale is correctly set from url
+    if (locale) activateLocale(locale);
+  }, [locale]);
+
+  return (
+    <Container px="xs" style={{ contain: "paint" }}>
+      <AppBar />
+      {currentAddress ? <InterestManifest /> : <NoAddressSection />}
+      <Footer />
+    </Container>
+  );
+}
+
+const NoAddressSection = () => {
+  const router: NextRouter = useRouter();
+  return (
+    <>
+      <Center mt={30}>
+        <Text fz="md" ta="center">
+          <Trans>
+            Provide an address to view a detailed accounting of how and when its
+            Aave positions accrued interest.
+          </Trans>
+        </Text>
+      </Center>
+      <Space h="md" />
+      <Center>
+        <Button onClick={() => router.push("/")}>
+          <Trans>Go to Simulator</Trans>
+        </Button>
+      </Center>
+    </>
+  );
+};

--- a/test/utils/tokenEventAccrual.test.ts
+++ b/test/utils/tokenEventAccrual.test.ts
@@ -2,11 +2,15 @@ import { BigNumber } from "ethers";
 
 import {
   TokenFlowEvent,
+  buildLedger,
   clampRoundingDust,
+  classifyEvent,
   findFirstPrincipalEvent,
   getAccruedInterest,
   getNetPrincipal,
+  getPendingInterest,
   getPrincipalFlow,
+  getRealizedInterest,
 } from "../../utils/tokenEventAccrual";
 
 let eventOrder = 0;
@@ -145,6 +149,160 @@ describe("findFirstPrincipalEvent", () => {
     expect(
       findFirstPrincipalEvent([event({ kind: "TransferOut", value: usdc(1) })])
     ).toBeUndefined();
+  });
+});
+
+describe("classifyEvent", () => {
+  it("classifies supply-side events", () => {
+    expect(
+      classifyEvent(
+        event({ kind: "Mint", value: usdc(102), balanceIncrease: usdc(2) }),
+        "supply"
+      )
+    ).toBe("Supply");
+    // withdrawal smaller than accrued interest emits a Mint with negative principal
+    expect(
+      classifyEvent(
+        event({ kind: "Mint", value: usdc(3), balanceIncrease: usdc(8) }),
+        "supply"
+      )
+    ).toBe("Withdraw");
+    expect(
+      classifyEvent(
+        event({ kind: "Burn", value: usdc(98), balanceIncrease: usdc(2) }),
+        "supply"
+      )
+    ).toBe("Withdraw");
+    expect(
+      classifyEvent(event({ kind: "TransferIn", value: usdc(50) }), "supply")
+    ).toBe("TransferIn");
+    expect(
+      classifyEvent(event({ kind: "TransferOut", value: usdc(50) }), "supply")
+    ).toBe("TransferOut");
+  });
+
+  it("classifies borrow-side events", () => {
+    expect(
+      classifyEvent(
+        event({ kind: "Mint", value: usdc(102), balanceIncrease: usdc(2) }),
+        "borrow"
+      )
+    ).toBe("Borrow");
+    // repayment smaller than accrued interest emits a Mint with negative principal
+    expect(
+      classifyEvent(
+        event({ kind: "Mint", value: usdc(3), balanceIncrease: usdc(8) }),
+        "borrow"
+      )
+    ).toBe("Repay");
+    expect(
+      classifyEvent(
+        event({ kind: "Burn", value: usdc(45), balanceIncrease: usdc(5) }),
+        "borrow"
+      )
+    ).toBe("Repay");
+  });
+
+  it("marks zero-principal index updates as interest application", () => {
+    const pureInterest = event({
+      kind: "Mint",
+      value: usdc(2),
+      balanceIncrease: usdc(2),
+    });
+    expect(classifyEvent(pureInterest, "supply")).toBe("InterestApplied");
+    expect(classifyEvent(pureInterest, "borrow")).toBe("InterestApplied");
+  });
+});
+
+describe("buildLedger", () => {
+  it("orders entries by chain order and carries event metadata", () => {
+    const later = event({
+      kind: "Burn",
+      value: usdc(28),
+      balanceIncrease: usdc(2),
+      blockNumber: 200,
+      logIndex: 3,
+      transactionHash: "0xbbb",
+      timestamp: 2000,
+    });
+    const earlier = event({
+      kind: "Mint",
+      value: usdc(100),
+      balanceIncrease: usdc(0),
+      blockNumber: 100,
+      logIndex: 1,
+      transactionHash: "0xaaa",
+      timestamp: 1000,
+    });
+
+    const ledger = buildLedger([later, earlier], "supply");
+
+    expect(ledger.map((entry) => entry.action)).toEqual(["Supply", "Withdraw"]);
+    expect(ledger[0]).toMatchObject({
+      principalDelta: usdc(100),
+      interestRealized: usdc(0),
+      blockNumber: 100,
+      transactionHash: "0xaaa",
+      timestamp: 1000,
+    });
+    expect(ledger[1]).toMatchObject({
+      principalDelta: usdc(-30),
+      interestRealized: usdc(2),
+      blockNumber: 200,
+      transactionHash: "0xbbb",
+      timestamp: 2000,
+    });
+  });
+
+  it("orders same-block entries by log index", () => {
+    const second = event({
+      kind: "Mint",
+      value: usdc(50),
+      balanceIncrease: usdc(0),
+      blockNumber: 100,
+      logIndex: 7,
+    });
+    const first = event({
+      kind: "TransferIn",
+      value: usdc(10),
+      blockNumber: 100,
+      logIndex: 2,
+    });
+
+    const ledger = buildLedger([second, first], "supply");
+
+    expect(ledger.map((entry) => entry.action)).toEqual([
+      "TransferIn",
+      "Supply",
+    ]);
+  });
+});
+
+describe("getRealizedInterest / getPendingInterest", () => {
+  it("splits lifetime interest into realized and pending parts", () => {
+    const events = [
+      event({ kind: "Mint", value: usdc(100), balanceIncrease: usdc(0) }), // supply 100
+      event({ kind: "Burn", value: usdc(28), balanceIncrease: usdc(2) }), // withdraw 30 after accruing 2
+    ];
+    // lifetime interest is 5 (see getAccruedInterest suite): 2 realized + 3 pending
+    expect(getRealizedInterest(events).toString()).toBe(usdc(2));
+    expect(getPendingInterest(usdc(75), events).toString()).toBe(usdc(3));
+  });
+
+  it("reports zero pending interest for a fully closed position", () => {
+    const events = [
+      event({ kind: "Mint", value: usdc(100), balanceIncrease: usdc(0) }),
+      // withdrew everything (108): Burn value = amount - balanceIncrease
+      event({ kind: "Burn", value: usdc(100), balanceIncrease: usdc(8) }),
+    ];
+    expect(getRealizedInterest(events).toString()).toBe(usdc(8));
+    expect(getPendingInterest(usdc(0), events).toString()).toBe("0");
+  });
+
+  it("treats transfers as realizing no interest", () => {
+    const events = [event({ kind: "TransferIn", value: usdc(100) })];
+    expect(getRealizedInterest(events).toString()).toBe("0");
+    expect(getPendingInterest(usdc(103), events).toString()).toBe(usdc(3));
   });
 });
 

--- a/utils/tokenEventAccrual.ts
+++ b/utils/tokenEventAccrual.ts
@@ -25,6 +25,8 @@ import { BigNumber } from "ethers";
 
 export type TokenFlowEventKind = "Mint" | "Burn" | "TransferIn" | "TransferOut";
 
+export type AccrualSide = "supply" | "borrow";
+
 export type TokenFlowEvent = {
   kind: TokenFlowEventKind;
   /** the event's `value` in underlying token base units */
@@ -33,6 +35,9 @@ export type TokenFlowEvent = {
   balanceIncrease?: string;
   blockNumber: number;
   logIndex: number;
+  transactionHash?: string;
+  /** unix seconds of the event's block, present once resolved */
+  timestamp?: number;
 };
 
 /** The signed principal delta (base units) contributed by a single event */
@@ -98,3 +103,88 @@ export const findFirstPrincipalEvent = (
         (event.kind === "Mint" || event.kind === "TransferIn") &&
         getPrincipalFlow(event).gt(0)
     );
+
+/**
+ * The user-facing meaning of a single token event. TransferIn / TransferOut
+ * cover aToken transfers between wallets, collateral swaps, and liquidation
+ * seizures. InterestApplied marks index updates that credited accrued interest
+ * to the balance without moving any principal.
+ */
+export type LedgerAction =
+  | "Supply"
+  | "Withdraw"
+  | "Borrow"
+  | "Repay"
+  | "TransferIn"
+  | "TransferOut"
+  | "InterestApplied";
+
+export type LedgerEntry = {
+  action: LedgerAction;
+  /** signed principal change in base units (positive = added to the position) */
+  principalDelta: string;
+  /** interest credited to the balance at this event, in base units */
+  interestRealized: string;
+  blockNumber: number;
+  logIndex: number;
+  transactionHash?: string;
+  /** unix seconds of the event's block */
+  timestamp?: number;
+};
+
+export const classifyEvent = (
+  event: TokenFlowEvent,
+  side: AccrualSide
+): LedgerAction => {
+  switch (event.kind) {
+    case "Mint": {
+      const principal = getPrincipalFlow(event);
+      if (principal.isZero()) return "InterestApplied";
+      // A withdrawal/repayment smaller than the interest accrued since the
+      // previous index update emits a Mint with a negative principal flow.
+      if (principal.gt(0)) return side === "borrow" ? "Borrow" : "Supply";
+      return side === "borrow" ? "Repay" : "Withdraw";
+    }
+    case "Burn":
+      return side === "borrow" ? "Repay" : "Withdraw";
+    case "TransferIn":
+      return "TransferIn";
+    case "TransferOut":
+    default:
+      return "TransferOut";
+  }
+};
+
+/** The chronological, classified accounting of every balance-changing event */
+export const buildLedger = (
+  events: TokenFlowEvent[],
+  side: AccrualSide
+): LedgerEntry[] =>
+  [...events].sort(byChainOrder).map((event) => ({
+    action: classifyEvent(event, side),
+    principalDelta: getPrincipalFlow(event).toString(),
+    interestRealized: BigNumber.from(event.balanceIncrease ?? 0).toString(),
+    blockNumber: event.blockNumber,
+    logIndex: event.logIndex,
+    transactionHash: event.transactionHash,
+    timestamp: event.timestamp,
+  }));
+
+/** Interest that was credited to the balance at past events, in base units */
+export const getRealizedInterest = (events: TokenFlowEvent[]): BigNumber =>
+  events.reduce(
+    (sum, event) => sum.add(BigNumber.from(event.balanceIncrease ?? 0)),
+    BigNumber.from(0)
+  );
+
+/**
+ * Interest accrued since the user's last balance-changing event, in base units:
+ * the part of the lifetime total not yet credited by any Mint/Burn.
+ */
+export const getPendingInterest = (
+  currentBalanceRaw: string,
+  events: TokenFlowEvent[]
+): BigNumber =>
+  getAccruedInterest(currentBalanceRaw, events).sub(
+    getRealizedInterest(events)
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated `/interest` page providing a thorough, per-event accounting of how and when interest accrued on a user's Aave positions — for both supplied assets and variable-rate borrows.

The accounting is exact, not estimated: it is reconstructed from on-chain aToken / variable debt token events, where each `Mint`/`Burn` carries a `balanceIncrease` equal to the interest credited since the user's previous interaction. The remainder (total accrued minus credited) is shown as "accruing since last activity."

## What's included

- **Data layer** (`utils/tokenEventAccrual.ts`): event classification (`Supply`, `Withdraw`, `Borrow`, `Repay`, `TransferIn/Out`, `InterestApplied`), a chronological ledger builder, and realized/pending interest helpers.
- **API layer** (`pages/api/aave/accrual`): optional per-event ledger with block timestamps and tx hashes (`includeLedger`), plus `getAccrualManifest` — a concurrency-limited scan of every reserve in a market to find interest history from positions closed in the past.
- **Hooks** (`hooks/useAccrualLedger.ts`): session-cached ledger fetching and an on-demand full-history scan with progress; scan results seed the per-position cache so nothing is fetched twice.
- **Page** (`pages/interest.tsx` + `components/InterestManifest.tsx`): per-asset ledger tables (date, action, principal change, interest credited, explorer tx link), side filter (All / Supplied / Borrowed), asset name filter, a final "accruing since last activity" row per asset, and an opt-in "Scan Full History" button that surfaces previously held positions.
- **Navigation**: AppBar link (toggles between Interest / Simulator) and "View full interest history" links in both asset details dialogs, all preserving the address query param.
- **Tests**: classification, ledger ordering/metadata, and realized/pending interest math (`test/utils/tokenEventAccrual.test.ts`).

## Notes / limitations

- Fiat values use current prices; historical prices aren't available.
- Non-standard tokens (e.g. GHO's discounted debt) show "Unavailable" via the same negative-value guard used by the existing accrued-interest displays.
- Stable-rate debt is out of scope, matching the existing accrual feature (v3 variable only).
- The page reflects the real on-chain position (`fetchedData`), never simulated edits.

## Verification

- `npx jest`: 1814 tests pass (24 in the accrual suite, including new ledger tests).
- `npm run build`: compiles cleanly; `/interest` prerenders for all locales.
- `tsc --noEmit`: no errors in any touched file (remaining errors are pre-existing on master).
- Manual browser test of page structure, navigation, filters, and empty/degraded states (this environment has no `NEXT_PUBLIC_ALCHEMY_API_KEY`, so live on-chain ledger data could not be exercised end-to-end — worth one spot-check with a real key before merging):

[interest-manifest-page-ui-test.mp4](https://cursor.com/agents/bc-70f4f8fd-2fe4-4727-aa03-68c9a3462892/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterest-manifest-page-ui-test.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70f4f8fd-2fe4-4727-aa03-68c9a3462892?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70f4f8fd-2fe4-4727-aa03-68c9a3462892&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

