### PR TITLE
Risk parameter overrides & shareable configurator (#16, #17)

### DIFF
--- a/components/AddAssetDialog.tsx
+++ b/components/AddAssetDialog.tsx
@@ -20,6 +20,7 @@ import {
   isBorrowableAsset,
   isSuppliableAsset,
 } from "../hooks/useAaveData";
+import { applyRiskOverridesToAsset } from "../utils/riskOverrides";
 import TokenIcon from "./TokenIcon";
 
 type AddAssetDialogProps = {
@@ -29,8 +30,13 @@ type AddAssetDialogProps = {
 export default function AddAssetDialog({ assetType }: AddAssetDialogProps) {
   const [open, setOpen] = React.useState(false);
   const [searchText, setSearchText] = React.useState("");
-  const { addressData, currentMarket, addBorrowAsset, addReserveAsset } =
-    useAaveData("");
+  const {
+    addressData,
+    currentMarket,
+    addBorrowAsset,
+    addReserveAsset,
+    effectiveRiskOverrides,
+  } = useAaveData("");
 
   const handleClose = () => {
     setSearchText("");
@@ -75,7 +81,15 @@ export default function AddAssetDialog({ assetType }: AddAssetDialogProps) {
           : !borrows.find((item) => item.asset.symbol === asset.symbol);
       })
       .filter((asset) => {
-        return assetType === "BORROW" ? isBorrowableAsset(asset) : isSuppliableAsset(asset);
+        // Apply simulated risk parameter overrides (e.g. frozen/paused or
+        // borrowable/collateral flags) before deciding availability.
+        const effectiveAsset = applyRiskOverridesToAsset(
+          asset,
+          effectiveRiskOverrides
+        );
+        return assetType === "BORROW"
+          ? isBorrowableAsset(effectiveAsset)
+          : isSuppliableAsset(effectiveAsset);
       })
     : new Array(...(addressData?.[currentMarket]?.availableAssets || []));
 

--- a/components/AddressCard.tsx
+++ b/components/AddressCard.tsx
@@ -65,6 +65,11 @@ import { AssetAPY } from "./AssetAPY";
 import ReserveAssetDetailsDialog from "./ReserveAssetDetailsDialog";
 import BorrowedAssetDetailsDialog from "./BorrowedAssetDetailsDialog";
 import { formatEModeLabel } from "../utils/liquidEMode";
+import {
+  AssetCapWarning,
+  RiskOverridesChip,
+  RiskParamsDialog,
+} from "./RiskParamsEditor";
 
 type Props = {};
 
@@ -462,6 +467,7 @@ const HealthFactorSummary = ({
                 </Text>
               </Mark>
               <ResetMarketButton />
+              <RiskOverridesChip />
             </Title>
           }
         />
@@ -1385,6 +1391,8 @@ const UserAssetItem = memo(
               ? <ReserveAssetDetailsDialog assetDetails={assetDetails} />
               : <BorrowedAssetDetailsDialog assetDetails={assetDetails} isStableBorrow={isStableBorrow} stableBorrowAPY={stableBorrowAPY} />
             }
+            <RiskParamsDialog assetSymbol={assetSymbol} assetType={assetType} />
+            <AssetCapWarning assetSymbol={assetSymbol} assetType={assetType} />
           </Group>
 
           <Tooltip

--- a/components/AddressCard.tsx
+++ b/components/AddressCard.tsx
@@ -70,6 +70,7 @@ import {
   RiskOverridesChip,
   RiskParamsDialog,
 } from "./RiskParamsEditor";
+import { ConfiguratorButton } from "./ConfiguratorDialog";
 
 type Props = {};
 
@@ -926,6 +927,9 @@ const ExtendedPositionDetails = ({ data }: ExtendedPositionDetailsProps) => {
                     {currBorrowPowerUsedDisplayable}
                   </Text>
                 </Paper>
+              </Grid.Col>
+              <Grid.Col span={12} style={{ textAlign: "center" }}>
+                <ConfiguratorButton />
               </Grid.Col>
             </Grid>
           );

--- a/components/BorrowedAssetDetailsDialog.tsx
+++ b/components/BorrowedAssetDetailsDialog.tsx
@@ -33,6 +33,7 @@ import { forwardRef } from "react";
 import { AssetLT } from "./AssetLT";
 import { AssetLTV } from "./AssetLTV";
 import { BorrowedAssetAPYAccrued } from "./BorrowedAssetAPYAccrued";
+import { RiskParamsEditor } from "./RiskParamsEditor";
 
 type BorrowedAssetDetailsDialogProps = {
     assetDetails: AssetDetails,
@@ -124,17 +125,19 @@ export default function BorrowedAssetDetailsDialog({ assetDetails, isStableBorro
 
                 <Divider label="Risk Parameters" mb={20} mt={20} labelPosition="center" />
 
-                <SimpleGrid cols={2} mb="xl">
+                <SimpleGrid cols={2} mb="md">
                     <AssetDetailsItem
                         title="Liquidation Threshold: "
                         description="The Liquidation Threshold refers to the loan to value percentage that makes the position subject to liquidation. This value represents the Liquidation Threshold provided by this asset."
-                        node={<AssetLT assetDetails={assetDetails} />} />
+                        node={<AssetLT assetDetails={asset.asset} />} />
                     <AssetDetailsItem
                         title="Max Loan to Value: "
                         description="Maximum Loan to Value refers to the loan to value percentage where new loans may not be initiated. This value represents the Maximum Loan to Value provided by this asset."
-                        node={<AssetLTV assetDetails={assetDetails} />} />
+                        node={<AssetLTV assetDetails={asset.asset} />} />
 
                 </SimpleGrid>
+
+                <RiskParamsEditor assetSymbol={assetDetails.symbol} assetType="BORROW" />
 
                 <Space h="xl" />
 

--- a/components/ConfigBanner.tsx
+++ b/components/ConfigBanner.tsx
@@ -1,0 +1,161 @@
+import { t, Trans } from "@lingui/macro";
+import { NextRouter, useRouter } from "next/router";
+import {
+  Alert,
+  Button,
+  Group,
+  Popover,
+  ScrollArea,
+  Switch,
+  Text,
+} from "@mantine/core";
+import { TbAdjustmentsHorizontal } from "react-icons/tb";
+
+import {
+  EModeCategoryData,
+  markets,
+  useAaveData,
+} from "../hooks/useAaveData";
+import { flattenRiskOverrides } from "../utils/riskOverrides";
+import { formatEModeLabel } from "../utils/liquidEMode";
+import {
+  formatRiskFieldValue,
+  getKnownAssets,
+  getRiskFieldLabel,
+  resolveOriginalRiskFieldValue,
+} from "./RiskParamsEditor";
+
+/**
+ * Banner shown when a shared risk parameter config (from a `?config=` URL)
+ * is loaded. Explains what the config simulates, links to the governance
+ * reference, and offers a live apply/disable toggle.
+ */
+export default function ConfigBanner() {
+  const router: NextRouter = useRouter();
+  const {
+    addressData,
+    sharedRiskConfig,
+    sharedRiskConfigEnabled,
+    setSharedRiskConfig,
+    setSharedRiskConfigEnabled,
+  } = useAaveData("");
+
+  if (!sharedRiskConfig) return null;
+
+  const market = markets.find((m) => m.id === sharedRiskConfig.marketId);
+  const overrides = sharedRiskConfig.overrides;
+  const entries = flattenRiskOverrides(overrides);
+  const label = overrides.meta?.label;
+  const refUrl = overrides.meta?.ref;
+
+  const configMarketData = addressData?.[sharedRiskConfig.marketId];
+  const knownAssets = getKnownAssets(configMarketData);
+  const eModes = configMarketData?.workingData?.eModes as
+    | EModeCategoryData[]
+    | undefined;
+
+  const handleDismiss = () => {
+    setSharedRiskConfig(null);
+    // Drop the config param so a refresh doesn't resurrect the banner.
+    const { config, ...remainingQuery } = router.query;
+    router.replace({ query: remainingQuery }, undefined, { shallow: true });
+  };
+
+  return (
+    <Alert
+      mt={15}
+      icon={<TbAdjustmentsHorizontal size="1rem" />}
+      title={
+        label ? (
+          <Trans>Simulated Risk Parameter Config: {label}</Trans>
+        ) : (
+          <Trans>Simulated Risk Parameter Config</Trans>
+        )
+      }
+      color="indigo"
+      variant="outline"
+      withCloseButton
+      onClose={handleDismiss}
+      closeButtonLabel={t`Remove config`}
+    >
+      <Text size="sm" mb="xs">
+        <Trans>
+          This link simulates changes to asset risk parameters in the{" "}
+          {market?.title || sharedRiskConfig.marketId} market. No real
+          positions or protocol settings are affected.
+        </Trans>
+      </Text>
+
+      <Group spacing="md">
+        <Switch
+          size="sm"
+          checked={sharedRiskConfigEnabled}
+          onChange={(event) =>
+            setSharedRiskConfigEnabled(event.currentTarget.checked)
+          }
+          label={t`Apply to simulation`}
+        />
+
+        <Popover width="300px" position="bottom" withArrow shadow="md">
+          <Popover.Target>
+            <Button variant="subtle" color="gray" compact>
+              <Trans>View changes ({entries.length})</Trans>
+            </Button>
+          </Popover.Target>
+          <Popover.Dropdown>
+            <ScrollArea.Autosize mah={220}>
+              {entries.map((entry) => {
+                const original = resolveOriginalRiskFieldValue(
+                  entry,
+                  knownAssets,
+                  eModes
+                );
+                const category = eModes?.find(
+                  (c) => String(c.id) === entry.key
+                );
+                const keyLabel =
+                  entry.kind === "asset"
+                    ? entry.key
+                    : t`E-Mode: ${formatEModeLabel(category?.label) || entry.key
+                      }`;
+                return (
+                  <Text
+                    size="xs"
+                    key={`${entry.kind}-${entry.key}-${entry.field}`}
+                    mb={4}
+                  >
+                    <Text span fw={600}>
+                      {keyLabel}
+                    </Text>
+                    {" — "}
+                    {getRiskFieldLabel(entry.field)}
+                    {": "}
+                    {original !== undefined && (
+                      <Text span c="dimmed">
+                        {formatRiskFieldValue(entry.field, original)} ➔{" "}
+                      </Text>
+                    )}
+                    <Text span fw={600}>
+                      {formatRiskFieldValue(entry.field, entry.value)}
+                    </Text>
+                  </Text>
+                );
+              })}
+            </ScrollArea.Autosize>
+          </Popover.Dropdown>
+        </Popover>
+
+        {refUrl && (
+          <a
+            href={refUrl}
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "#e9ecef", fontSize: "13px" }}
+          >
+            <Trans>View reference</Trans>
+          </a>
+        )}
+      </Group>
+    </Alert>
+  );
+}

--- a/components/ConfiguratorDialog.tsx
+++ b/components/ConfiguratorDialog.tsx
@@ -1,0 +1,615 @@
+import * as React from "react";
+import { t, Trans } from "@lingui/macro";
+import { NextRouter, useRouter } from "next/router";
+
+import {
+  Accordion,
+  Button,
+  Center,
+  Checkbox,
+  Divider,
+  Group,
+  Modal,
+  ScrollArea,
+  Select,
+  Space,
+  Stepper,
+  Text,
+  TextInput,
+  Tooltip,
+} from "@mantine/core";
+import { RxReset } from "react-icons/rx";
+import { FaBolt, FaCopy } from "react-icons/fa";
+import { TbAdjustmentsHorizontal } from "react-icons/tb";
+
+import {
+  AssetDetails,
+  EModeCategoryData,
+  markets,
+  useAaveData,
+} from "../hooks/useAaveData";
+import {
+  AssetRiskOverride,
+  EModeCategoryOverride,
+  SharedRiskConfig,
+  encodeRiskConfig,
+  hasAnyRiskOverrides,
+  sanitizeRiskOverrides,
+} from "../utils/riskOverrides";
+import { formatEModeLabel } from "../utils/liquidEMode";
+import TokenIcon from "./TokenIcon";
+import {
+  CapOverrideField,
+  FlagOverrideField,
+  PercentOverrideField,
+  getKnownAssets,
+} from "./RiskParamsEditor";
+
+/**
+ * Wizard that builds a shareable risk parameter config URL (#17):
+ * pick a market, pick assets, set parameters, then copy the generated
+ * link (or apply the config immediately to this session).
+ */
+
+type ConfiguratorDialogProps = {
+  opened: boolean;
+  onClose: () => void;
+};
+
+export const ConfiguratorDialog = ({
+  opened,
+  onClose,
+}: ConfiguratorDialogProps) => {
+  const router: NextRouter = useRouter();
+  const { addressData, currentMarket, currentAddress, setSharedRiskConfig } =
+    useAaveData("", true);
+
+  const [step, setStep] = React.useState(0);
+  const [marketId, setMarketId] = React.useState<string>(currentMarket);
+  const [searchText, setSearchText] = React.useState("");
+  const [selectedSymbols, setSelectedSymbols] = React.useState<string[]>([]);
+  const [assetDrafts, setAssetDrafts] = React.useState<
+    Record<string, AssetRiskOverride>
+  >({});
+  const [categoryDrafts, setCategoryDrafts] = React.useState<
+    Record<string, EModeCategoryOverride>
+  >({});
+  const [configLabel, setConfigLabel] = React.useState("");
+  const [configRef, setConfigRef] = React.useState("");
+  const [showCopied, setShowCopied] = React.useState(false);
+
+  const marketData = addressData?.[marketId];
+  const knownAssets = getKnownAssets(marketData).sort((a, b) =>
+    a.symbol.localeCompare(b.symbol)
+  );
+  const eModes = (marketData?.workingData?.eModes || []) as EModeCategoryData[];
+
+  const resetWizard = () => {
+    setStep(0);
+    setSearchText("");
+    setSelectedSymbols([]);
+    setAssetDrafts({});
+    setCategoryDrafts({});
+    setConfigLabel("");
+    setConfigRef("");
+  };
+
+  const handleClose = () => {
+    resetWizard();
+    onClose();
+  };
+
+  const setAssetDraftField = (
+    symbol: string,
+    field: string,
+    value: number | boolean | undefined
+  ) => {
+    setAssetDrafts((prev) => {
+      const draft: Record<string, number | boolean | undefined> = {
+        ...(prev[symbol] || {}),
+      };
+      if (value === undefined) {
+        delete draft[field];
+      } else {
+        draft[field] = value;
+      }
+      return { ...prev, [symbol]: draft as AssetRiskOverride };
+    });
+  };
+
+  const setCategoryDraftField = (
+    categoryId: number,
+    field: "ltv" | "liquidationThreshold",
+    value: number | undefined
+  ) => {
+    setCategoryDrafts((prev) => {
+      const draft: Record<string, number | undefined> = {
+        ...(prev[String(categoryId)] || {}),
+      };
+      if (value === undefined) {
+        delete draft[field];
+      } else {
+        draft[field] = value;
+      }
+      return { ...prev, [String(categoryId)]: draft as EModeCategoryOverride };
+    });
+  };
+
+  const buildConfig = (): SharedRiskConfig | null => {
+    const assets: Record<string, AssetRiskOverride> = {};
+    selectedSymbols.forEach((symbol) => {
+      if (assetDrafts[symbol] && Object.keys(assetDrafts[symbol]).length) {
+        assets[symbol] = assetDrafts[symbol];
+      }
+    });
+    const overrides = sanitizeRiskOverrides({
+      assets,
+      eModeCategories: categoryDrafts,
+      meta: { label: configLabel, ref: configRef },
+    });
+    if (!hasAnyRiskOverrides(overrides)) return null;
+    return { marketId, overrides };
+  };
+
+  const config = buildConfig();
+  const encoded = config ? encodeRiskConfig(config) : "";
+  const shareUrl =
+    config && typeof window !== "undefined"
+      ? `${window.location.origin}/?${currentAddress ? `address=${currentAddress}&` : ""
+      }config=${encoded}`
+      : "";
+
+  const handleCopy = () => {
+    if (!shareUrl) return;
+    navigator.clipboard.writeText(shareUrl);
+    setShowCopied(true);
+    setTimeout(() => setShowCopied(false), 2500);
+  };
+
+  const handleApply = () => {
+    if (!config) return;
+    setSharedRiskConfig(config);
+    // Reflect the config in the URL so a refresh (or copied address bar)
+    // preserves it.
+    router.replace(
+      { query: { ...router.query, config: encoded } },
+      undefined,
+      { shallow: true }
+    );
+    handleClose();
+  };
+
+  const filteredAssets = knownAssets.filter((asset) => {
+    if (!searchText.length) return true;
+    return (
+      asset.name?.toUpperCase().includes(searchText.toUpperCase()) ||
+      asset.symbol?.toUpperCase().includes(searchText.toUpperCase())
+    );
+  });
+
+  const draftCount =
+    Object.values(assetDrafts).reduce(
+      (acc, draft) => acc + Object.keys(draft).length,
+      0
+    ) +
+    Object.values(categoryDrafts).reduce(
+      (acc, draft) => acc + Object.keys(draft).length,
+      0
+    );
+
+  return (
+    <Modal
+      size="xl"
+      opened={opened}
+      onClose={handleClose}
+      title={t`Risk Parameter Configurator`}
+    >
+      <Text size="sm" c="dimmed" mb="md">
+        <Trans>
+          Build a shareable link that simulates asset risk parameter changes,
+          e.g. a pending governance proposal. Anyone opening the link sees the
+          changes applied to their position, with a toggle to compare.
+        </Trans>
+      </Text>
+
+      <Stepper active={step} onStepClick={setStep} size="xs" breakpoint="xs">
+        <Stepper.Step label={t`Market`}>
+          <Space h="md" />
+          <Select
+            label={t`Market`}
+            description={t`The market whose risk parameters the config changes.`}
+            value={marketId}
+            onChange={(value) => {
+              if (!value || value === marketId) return;
+              setMarketId(value);
+              setSelectedSymbols([]);
+              setAssetDrafts({});
+              setCategoryDrafts({});
+            }}
+            data={markets.map((market) => ({
+              value: market.id,
+              label: market.title,
+            }))}
+          />
+          <Group position="right" mt="lg">
+            <Button onClick={() => setStep(1)}>
+              <Trans>Next: Select Assets</Trans>
+            </Button>
+          </Group>
+        </Stepper.Step>
+
+        <Stepper.Step label={t`Assets`}>
+          <Space h="md" />
+          {knownAssets.length === 0 ? (
+            <Text size="sm">
+              <Trans>
+                No asset data is loaded for this market yet. Load an address
+                first so asset details are available.
+              </Trans>
+            </Text>
+          ) : (
+            <>
+              <TextInput
+                value={searchText}
+                label={t`Search Assets`}
+                onChange={(e) => setSearchText(e.target.value)}
+                size="sm"
+                mb={8}
+                rightSection={
+                  searchText?.length > 0 && (
+                    <Tooltip
+                      label={t`Reset search query`}
+                      position="top-end"
+                      withArrow
+                    >
+                      <RxReset
+                        size={18}
+                        style={{ display: "block", cursor: "pointer" }}
+                        onClick={() => setSearchText("")}
+                      />
+                    </Tooltip>
+                  )
+                }
+              />
+              <ScrollArea.Autosize mah={260}>
+                {filteredAssets.map((asset) => (
+                  <Checkbox
+                    key={asset.symbol}
+                    size="sm"
+                    mb={6}
+                    checked={selectedSymbols.includes(asset.symbol)}
+                    onChange={(e) => {
+                      setSelectedSymbols((prev) =>
+                        e.currentTarget.checked
+                          ? [...prev, asset.symbol]
+                          : prev.filter((s) => s !== asset.symbol)
+                      );
+                    }}
+                    label={
+                      <Group spacing={6}>
+                        <TokenIcon
+                          symbol={asset.symbol}
+                          size="18px"
+                          alt={asset.symbol}
+                        />
+                        <Text size="sm">{asset.symbol}</Text>
+                      </Group>
+                    }
+                  />
+                ))}
+              </ScrollArea.Autosize>
+            </>
+          )}
+          <Group position="apart" mt="lg">
+            <Button variant="subtle" color="gray" onClick={() => setStep(0)}>
+              <Trans>Back</Trans>
+            </Button>
+            <Button
+              onClick={() => setStep(2)}
+              disabled={!selectedSymbols.length && !eModes.length}
+            >
+              <Trans>Next: Set Parameters</Trans>
+            </Button>
+          </Group>
+        </Stepper.Step>
+
+        <Stepper.Step label={t`Parameters`}>
+          <Space h="md" />
+          {selectedSymbols.length > 0 && (
+            <Accordion variant="separated" multiple>
+              {selectedSymbols.map((symbol) => {
+                const asset = knownAssets.find(
+                  (a) => a.symbol === symbol
+                ) as AssetDetails;
+                if (!asset) return null;
+                const draft = assetDrafts[symbol] || {};
+                const overriddenCount = Object.keys(draft).length;
+                return (
+                  <Accordion.Item value={symbol} key={symbol}>
+                    <Accordion.Control
+                      icon={
+                        <TokenIcon
+                          symbol={symbol}
+                          size="20px"
+                          alt={symbol}
+                        />
+                      }
+                    >
+                      <Group spacing={8}>
+                        <Text fw={600}>{symbol}</Text>
+                        {overriddenCount > 0 && (
+                          <Text size="xs" c="#FFFF00">
+                            <Trans>({overriddenCount} changed)</Trans>
+                          </Text>
+                        )}
+                      </Group>
+                    </Accordion.Control>
+                    <Accordion.Panel>
+                      <Group grow align="flex-start" mb="xs">
+                        <PercentOverrideField
+                          label={t`Max LTV`}
+                          originalBps={asset.baseLTVasCollateral}
+                          overrideBps={draft.ltv}
+                          onOverrideChange={(bps) =>
+                            setAssetDraftField(symbol, "ltv", bps)
+                          }
+                        />
+                        <PercentOverrideField
+                          label={t`Liquidation Threshold`}
+                          originalBps={asset.reserveLiquidationThreshold}
+                          overrideBps={draft.liquidationThreshold}
+                          onOverrideChange={(bps) =>
+                            setAssetDraftField(
+                              symbol,
+                              "liquidationThreshold",
+                              bps
+                            )
+                          }
+                        />
+                      </Group>
+                      <Group grow align="flex-start" mb="xs">
+                        <CapOverrideField
+                          label={t`Supply Cap`}
+                          description={t`0 means no cap`}
+                          originalCap={asset.supplyCap}
+                          overrideCap={draft.supplyCap}
+                          onOverrideChange={(cap) =>
+                            setAssetDraftField(symbol, "supplyCap", cap)
+                          }
+                        />
+                        <CapOverrideField
+                          label={t`Borrow Cap`}
+                          description={t`0 means no cap`}
+                          originalCap={asset.borrowCap}
+                          overrideCap={draft.borrowCap}
+                          onOverrideChange={(cap) =>
+                            setAssetDraftField(symbol, "borrowCap", cap)
+                          }
+                        />
+                      </Group>
+                      <FlagOverrideField
+                        label={t`Usable as Collateral`}
+                        originalValue={asset.usageAsCollateralEnabled}
+                        overrideValue={draft.usageAsCollateralEnabled}
+                        onOverrideChange={(value) =>
+                          setAssetDraftField(
+                            symbol,
+                            "usageAsCollateralEnabled",
+                            value
+                          )
+                        }
+                      />
+                      <FlagOverrideField
+                        label={t`Borrowing Enabled`}
+                        originalValue={asset.borrowingEnabled}
+                        overrideValue={draft.borrowingEnabled}
+                        onOverrideChange={(value) =>
+                          setAssetDraftField(symbol, "borrowingEnabled", value)
+                        }
+                      />
+                      <FlagOverrideField
+                        label={t`Frozen`}
+                        originalValue={asset.isFrozen}
+                        overrideValue={draft.isFrozen}
+                        onOverrideChange={(value) =>
+                          setAssetDraftField(symbol, "isFrozen", value)
+                        }
+                      />
+                      <FlagOverrideField
+                        label={t`Paused`}
+                        originalValue={asset.isPaused}
+                        overrideValue={draft.isPaused}
+                        onOverrideChange={(value) =>
+                          setAssetDraftField(symbol, "isPaused", value)
+                        }
+                      />
+                    </Accordion.Panel>
+                  </Accordion.Item>
+                );
+              })}
+            </Accordion>
+          )}
+
+          {eModes.length > 0 && (
+            <>
+              <Divider
+                label={
+                  <Text size="xs">
+                    <FaBolt /> <Trans>E-Mode Categories</Trans>
+                  </Text>
+                }
+                mb={8}
+                mt={16}
+                labelPosition="center"
+              />
+              <Text size="xs" c="dimmed" mb="xs">
+                <Trans>
+                  Category values apply to every asset that participates in
+                  the category while E-Mode is active.
+                </Trans>
+              </Text>
+              <Accordion variant="separated" multiple>
+                {eModes.map((category) => {
+                  const draft = categoryDrafts[String(category.id)] || {};
+                  const overriddenCount = Object.keys(draft).length;
+                  return (
+                    <Accordion.Item
+                      value={String(category.id)}
+                      key={category.id}
+                    >
+                      <Accordion.Control>
+                        <Group spacing={8}>
+                          <Text fw={600} size="sm">
+                            {formatEModeLabel(category.label) || category.id}
+                          </Text>
+                          {overriddenCount > 0 && (
+                            <Text size="xs" c="#FFFF00">
+                              <Trans>({overriddenCount} changed)</Trans>
+                            </Text>
+                          )}
+                        </Group>
+                      </Accordion.Control>
+                      <Accordion.Panel>
+                        <Group grow align="flex-start">
+                          <PercentOverrideField
+                            label={t`E-Mode Max LTV`}
+                            originalBps={category.ltv}
+                            overrideBps={draft.ltv}
+                            onOverrideChange={(bps) =>
+                              setCategoryDraftField(category.id, "ltv", bps)
+                            }
+                          />
+                          <PercentOverrideField
+                            label={t`E-Mode Liquidation Threshold`}
+                            originalBps={category.liquidationThreshold}
+                            overrideBps={draft.liquidationThreshold}
+                            onOverrideChange={(bps) =>
+                              setCategoryDraftField(
+                                category.id,
+                                "liquidationThreshold",
+                                bps
+                              )
+                            }
+                          />
+                        </Group>
+                      </Accordion.Panel>
+                    </Accordion.Item>
+                  );
+                })}
+              </Accordion>
+            </>
+          )}
+
+          <Group position="apart" mt="lg">
+            <Button variant="subtle" color="gray" onClick={() => setStep(1)}>
+              <Trans>Back</Trans>
+            </Button>
+            <Button onClick={() => setStep(3)} disabled={!draftCount}>
+              <Trans>Next: Review & Share</Trans>
+            </Button>
+          </Group>
+        </Stepper.Step>
+
+        <Stepper.Step label={t`Share`}>
+          <Space h="md" />
+          <TextInput
+            value={configLabel}
+            label={t`Config Label (optional)`}
+            description={t`Shown in the banner when someone opens the link.`}
+            placeholder={t`e.g. Gauntlet WETH parameter update`}
+            onChange={(e) => setConfigLabel(e.target.value)}
+            size="sm"
+            mb={8}
+          />
+          <TextInput
+            value={configRef}
+            label={t`Reference URL (optional)`}
+            description={t`e.g. an Aave governance forum post explaining the change.`}
+            placeholder="https://governance.aave.com/t/..."
+            onChange={(e) => setConfigRef(e.target.value)}
+            size="sm"
+            mb={8}
+          />
+
+          {config ? (
+            <>
+              <TextInput
+                value={shareUrl}
+                label={t`Shareable Link`}
+                readOnly
+                size="sm"
+                mb={8}
+                rightSection={
+                  <Tooltip
+                    label={
+                      showCopied
+                        ? t`Link copied to clipboard!`
+                        : t`Copy link to clipboard`
+                    }
+                    opened={showCopied ? true : undefined}
+                    color={showCopied ? "green" : undefined}
+                    position="top-end"
+                    withArrow
+                  >
+                    <span>
+                      <FaCopy
+                        style={{ cursor: "pointer" }}
+                        onClick={handleCopy}
+                      />
+                    </span>
+                  </Tooltip>
+                }
+              />
+              <Group position="apart" mt="lg">
+                <Button
+                  variant="subtle"
+                  color="gray"
+                  onClick={() => setStep(2)}
+                >
+                  <Trans>Back</Trans>
+                </Button>
+                <Group>
+                  <Button variant="outline" onClick={handleCopy}>
+                    <Trans>Copy Link</Trans>
+                  </Button>
+                  <Button onClick={handleApply}>
+                    <Trans>Apply Now</Trans>
+                  </Button>
+                </Group>
+              </Group>
+            </>
+          ) : (
+            <Text size="sm" mt="md">
+              <Trans>
+                No parameter changes configured yet. Go back and adjust at
+                least one parameter.
+              </Trans>
+            </Text>
+          )}
+        </Stepper.Step>
+      </Stepper>
+    </Modal>
+  );
+};
+
+/** Button entry point for the configurator. */
+export const ConfiguratorButton = () => {
+  const [opened, setOpened] = React.useState(false);
+
+  return (
+    <>
+      {opened && (
+        <ConfiguratorDialog opened={opened} onClose={() => setOpened(false)} />
+      )}
+      <Button
+        variant="subtle"
+        color="gray"
+        compact
+        leftIcon={<TbAdjustmentsHorizontal size={14} />}
+        onClick={() => setOpened(true)}
+      >
+        <Trans>Risk Parameter Configurator</Trans>
+      </Button>
+    </>
+  );
+};

--- a/components/ReserveAssetDetailsDialog.tsx
+++ b/components/ReserveAssetDetailsDialog.tsx
@@ -31,6 +31,7 @@ import { ReserveAssetAPYAccrued } from "./ReserveAssetAPYAccrued";
 import { forwardRef } from "react";
 import { AssetLT } from "./AssetLT";
 import { AssetLTV } from "./AssetLTV";
+import { RiskParamsEditor } from "./RiskParamsEditor";
 
 type ReserveAssetDetailsDialogProps = {
     assetDetails: AssetDetails
@@ -124,17 +125,19 @@ export default function ReserveAssetDetailsDialog({ assetDetails }: ReserveAsset
 
                 <Divider label="Risk Parameters" mb={20} mt={20} labelPosition="center" />
 
-                <SimpleGrid cols={2} mb="xl">
+                <SimpleGrid cols={2} mb="md">
                     <AssetDetailsItem
                         title="Liquidation Threshold: "
                         description="The Liquidation Threshold refers to the loan to value percentage that makes the position subject to liquidation. This value represents the Liquidation Threshold provided by this asset."
-                        node={<AssetLT assetDetails={assetDetails} />} />
+                        node={<AssetLT assetDetails={asset.asset} />} />
                     <AssetDetailsItem
                         title="Max Loan to Value: "
                         description="Maximum Loan to Value refers to the loan to value percentage where new loans may not be initiated. This value represents the Maximum Loan to Value provided by this asset."
-                        node={<AssetLTV assetDetails={assetDetails} />} />
+                        node={<AssetLTV assetDetails={asset.asset} />} />
 
                 </SimpleGrid>
+
+                <RiskParamsEditor assetSymbol={assetDetails.symbol} assetType="RESERVE" />
 
                 <Space h="xl" />
 

--- a/components/RiskParamsEditor.tsx
+++ b/components/RiskParamsEditor.tsx
@@ -33,8 +33,10 @@ import {
 import {
   RiskOverrideEntry,
   RiskParamOverrides,
+  encodeRiskConfig,
   flattenRiskOverrides,
   hasAnyRiskOverrides,
+  sanitizeRiskOverrides,
 } from "../utils/riskOverrides";
 import { formatEModeLabel } from "../utils/liquidEMode";
 import { formatNumber } from "accounting";
@@ -135,7 +137,7 @@ export const resolveOriginalRiskFieldValue = (
 };
 
 /** Collect every asset we know about (position + available) for diffing. */
-const getKnownAssets = (marketData: any): AssetDetails[] => {
+export const getKnownAssets = (marketData: any): AssetDetails[] => {
   const assets: AssetDetails[] = [];
   marketData?.workingData?.userReservesData?.forEach(
     (item: ReserveAssetDataItem) => assets.push(item.asset)
@@ -818,15 +820,28 @@ export const RiskOverridesChip = () => {
   const {
     addressData,
     currentMarket,
+    currentAddress,
     effectiveRiskOverrides,
     riskOverrides,
     clearAllRiskOverrides,
   } = useAaveData("", true);
+  const [showCopied, setShowCopied] = React.useState(false);
 
   const marketData = addressData?.[currentMarket];
   const entries = flattenRiskOverrides(effectiveRiskOverrides);
 
   if (!entries.length) return null;
+
+  const handleShare = () => {
+    const overrides = sanitizeRiskOverrides(effectiveRiskOverrides);
+    if (!hasAnyRiskOverrides(overrides)) return;
+    const encoded = encodeRiskConfig({ marketId: currentMarket, overrides });
+    const url = `${window.location.origin}/?${currentAddress ? `address=${currentAddress}&` : ""
+      }config=${encoded}`;
+    navigator.clipboard.writeText(url);
+    setShowCopied(true);
+    setTimeout(() => setShowCopied(false), 2500);
+  };
 
   const knownAssets = getKnownAssets(marketData);
   const eModes = marketData?.workingData?.eModes as
@@ -889,18 +904,33 @@ export const RiskOverridesChip = () => {
             );
           })}
         </ScrollArea.Autosize>
-        {hasManualOverrides && (
-          <Group position="center" mt="sm">
+        <Group position="center" mt="sm" spacing="xs">
+          <Tooltip
+            label={t`Link copied to clipboard!`}
+            opened={showCopied}
+            color="green"
+            withArrow
+          >
+            <Button
+              variant="subtle"
+              color="gray"
+              compact
+              onClick={handleShare}
+            >
+              <Trans>Copy shareable link</Trans>
+            </Button>
+          </Tooltip>
+          {hasManualOverrides && (
             <Button
               variant="subtle"
               color="gray"
               compact
               onClick={clearAllRiskOverrides}
             >
-              <Trans>Clear all risk parameter changes</Trans>
+              <Trans>Clear all</Trans>
             </Button>
-          </Group>
-        )}
+          )}
+        </Group>
       </Popover.Dropdown>
     </Popover>
   );

--- a/components/RiskParamsEditor.tsx
+++ b/components/RiskParamsEditor.tsx
@@ -1,0 +1,907 @@
+import * as React from "react";
+import { t, Trans } from "@lingui/macro";
+
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Checkbox,
+  Divider,
+  Group,
+  Indicator,
+  Mark,
+  Modal,
+  Popover,
+  ScrollArea,
+  Text,
+  TextInput,
+  Tooltip,
+} from "@mantine/core";
+import { RxReset } from "react-icons/rx";
+import { TbAdjustmentsHorizontal } from "react-icons/tb";
+import { FiAlertTriangle } from "react-icons/fi";
+import { FaBolt } from "react-icons/fa";
+
+import {
+  AssetDetails,
+  BorrowedAssetDataItem,
+  EModeCategoryData,
+  ReserveAssetDataItem,
+  getHealthFactorColor,
+  useAaveData,
+} from "../hooks/useAaveData";
+import {
+  RiskOverrideEntry,
+  RiskParamOverrides,
+  flattenRiskOverrides,
+  hasAnyRiskOverrides,
+} from "../utils/riskOverrides";
+import { formatEModeLabel } from "../utils/liquidEMode";
+import { formatNumber } from "accounting";
+
+/**
+ *
+ * Shared helpers for labeling/formatting risk parameter fields.
+ *
+ */
+
+export const getRiskFieldLabel = (field: string): string => {
+  switch (field) {
+    case "ltv":
+      return t`Max LTV`;
+    case "liquidationThreshold":
+      return t`Liquidation Threshold`;
+    case "eModeLtv":
+      return t`E-Mode Max LTV`;
+    case "eModeLiquidationThreshold":
+      return t`E-Mode Liquidation Threshold`;
+    case "supplyCap":
+      return t`Supply Cap`;
+    case "borrowCap":
+      return t`Borrow Cap`;
+    case "borrowingEnabled":
+      return t`Borrowing Enabled`;
+    case "usageAsCollateralEnabled":
+      return t`Usable as Collateral`;
+    case "isFrozen":
+      return t`Frozen`;
+    case "isPaused":
+      return t`Paused`;
+    default:
+      return field;
+  }
+};
+
+export const formatRiskFieldValue = (
+  field: string,
+  value: number | boolean | undefined
+): string => {
+  if (value === undefined) return "---";
+  if (typeof value === "boolean") return value ? t`Yes` : t`No`;
+  switch (field) {
+    case "ltv":
+    case "liquidationThreshold":
+    case "eModeLtv":
+    case "eModeLiquidationThreshold":
+      return `${(value / 100).toFixed(1)}%`;
+    case "supplyCap":
+    case "borrowCap":
+      return value === 0 ? t`None` : formatNumber(value);
+    default:
+      return String(value);
+  }
+};
+
+/**
+ * Resolve the original (on-chain) value of an overridden field, for
+ * "original ➔ new" diffs in chips and banners.
+ */
+export const resolveOriginalRiskFieldValue = (
+  entry: RiskOverrideEntry,
+  assets: AssetDetails[],
+  eModes?: EModeCategoryData[]
+): number | boolean | undefined => {
+  if (entry.kind === "eModeCategory") {
+    const category = eModes?.find((c) => String(c.id) === entry.key);
+    if (!category) return undefined;
+    return entry.field === "ltv" ? category.ltv : category.liquidationThreshold;
+  }
+  const asset = assets.find((a) => a.symbol === entry.key);
+  if (!asset) return undefined;
+  switch (entry.field) {
+    case "ltv":
+      return asset.baseLTVasCollateral;
+    case "liquidationThreshold":
+      return asset.reserveLiquidationThreshold;
+    case "eModeLtv":
+      return asset.eModeLtv;
+    case "eModeLiquidationThreshold":
+      return asset.eModeLiquidationThreshold;
+    case "supplyCap":
+      return asset.supplyCap;
+    case "borrowCap":
+      return asset.borrowCap;
+    case "borrowingEnabled":
+      return asset.borrowingEnabled;
+    case "usageAsCollateralEnabled":
+      return asset.usageAsCollateralEnabled;
+    case "isFrozen":
+      return asset.isFrozen;
+    case "isPaused":
+      return asset.isPaused;
+    default:
+      return undefined;
+  }
+};
+
+/** Collect every asset we know about (position + available) for diffing. */
+const getKnownAssets = (marketData: any): AssetDetails[] => {
+  const assets: AssetDetails[] = [];
+  marketData?.workingData?.userReservesData?.forEach(
+    (item: ReserveAssetDataItem) => assets.push(item.asset)
+  );
+  marketData?.workingData?.userBorrowsData?.forEach(
+    (item: BorrowedAssetDataItem) => {
+      if (!assets.find((a) => a.symbol === item.asset.symbol))
+        assets.push(item.asset);
+    }
+  );
+  marketData?.availableAssets?.forEach((asset: AssetDetails) => {
+    if (!assets.find((a) => a.symbol === asset.symbol)) assets.push(asset);
+  });
+  return assets;
+};
+
+/**
+ *
+ * Field primitives. Controlled by (original, override) pairs so they can be
+ * wired either to the store (RiskParamsEditor) or to local draft state
+ * (ConfiguratorDialog).
+ *
+ */
+
+type PercentOverrideFieldProps = {
+  label: string;
+  description?: string;
+  /** basis points */
+  originalBps?: number;
+  /** basis points */
+  overrideBps?: number;
+  onOverrideChange: (bps: number | undefined) => void;
+  /** shown dimmed with a hint that the field is not currently in effect */
+  inactiveHint?: string;
+};
+
+export const PercentOverrideField = ({
+  label,
+  description,
+  originalBps,
+  overrideBps,
+  onOverrideChange,
+  inactiveHint,
+}: PercentOverrideFieldProps) => {
+  const original = originalBps ?? 0;
+  const effective = overrideBps ?? original;
+  const isOverridden =
+    overrideBps !== undefined && overrideBps !== original;
+
+  const handleChange = (raw: string) => {
+    if (raw === "") {
+      onOverrideChange(undefined);
+      return;
+    }
+    const pct = Number(raw);
+    if (!Number.isFinite(pct) || pct < 0) return;
+    const bps = Math.round(Math.min(pct, 100) * 100);
+    onOverrideChange(bps === original ? undefined : bps);
+  };
+
+  const resetIcon = isOverridden ? (
+    <Tooltip
+      label={t`Reset to Original Value (${(original / 100).toFixed(1)}%)`}
+      position="top-end"
+      withArrow
+    >
+      <ActionIcon>
+        <RxReset
+          size={18}
+          style={{ display: "block" }}
+          onClick={() => onOverrideChange(undefined)}
+          color="#FFFF00"
+        />
+      </ActionIcon>
+    </Tooltip>
+  ) : null;
+
+  return (
+    <div>
+      <TextInput
+        value={String(Number((effective / 100).toFixed(2)))}
+        label={label}
+        description={description}
+        labelProps={{ size: "sm" }}
+        onChange={(e) => handleChange(e.target.value)}
+        size="sm"
+        type="number"
+        step={0.5}
+        min={0}
+        max={100}
+        icon={<Text size="xs">%</Text>}
+        inputWrapperOrder={["label", "error", "input", "description"]}
+        inputContainer={(children) => (
+          <Indicator zIndex="3" disabled={!isOverridden} color="#FFFF00">
+            {children}
+          </Indicator>
+        )}
+        rightSection={resetIcon}
+      />
+      {isOverridden && (
+        <Text fz="xs" c="dimmed">
+          {`${(original / 100).toFixed(1)}%`} ➔{" "}
+          {`${(effective / 100).toFixed(1)}%`}
+        </Text>
+      )}
+      {inactiveHint && (
+        <Text fz="xs" c="dimmed" mt={2}>
+          {inactiveHint}
+        </Text>
+      )}
+    </div>
+  );
+};
+
+type CapOverrideFieldProps = {
+  label: string;
+  description?: string;
+  /** whole tokens, 0 = uncapped */
+  originalCap?: number;
+  overrideCap?: number;
+  onOverrideChange: (cap: number | undefined) => void;
+};
+
+export const CapOverrideField = ({
+  label,
+  description,
+  originalCap,
+  overrideCap,
+  onOverrideChange,
+}: CapOverrideFieldProps) => {
+  const original = originalCap ?? 0;
+  const effective = overrideCap ?? original;
+  const isOverridden = overrideCap !== undefined && overrideCap !== original;
+
+  const handleChange = (raw: string) => {
+    if (raw === "") {
+      onOverrideChange(undefined);
+      return;
+    }
+    const cap = Number(raw);
+    if (!Number.isFinite(cap) || cap < 0) return;
+    onOverrideChange(cap === original ? undefined : cap);
+  };
+
+  const resetIcon = isOverridden ? (
+    <Tooltip
+      label={t`Reset to Original Value (${formatRiskFieldValue(
+        "supplyCap",
+        original
+      )})`}
+      position="top-end"
+      withArrow
+    >
+      <ActionIcon>
+        <RxReset
+          size={18}
+          style={{ display: "block" }}
+          onClick={() => onOverrideChange(undefined)}
+          color="#FFFF00"
+        />
+      </ActionIcon>
+    </Tooltip>
+  ) : null;
+
+  return (
+    <div>
+      <TextInput
+        value={String(effective)}
+        label={label}
+        description={description}
+        labelProps={{ size: "sm" }}
+        onChange={(e) => handleChange(e.target.value)}
+        size="sm"
+        type="number"
+        min={0}
+        inputWrapperOrder={["label", "error", "input", "description"]}
+        inputContainer={(children) => (
+          <Indicator zIndex="3" disabled={!isOverridden} color="#FFFF00">
+            {children}
+          </Indicator>
+        )}
+        rightSection={resetIcon}
+      />
+      {isOverridden && (
+        <Text fz="xs" c="dimmed">
+          {formatRiskFieldValue("supplyCap", original)} ➔{" "}
+          {formatRiskFieldValue("supplyCap", effective)}
+        </Text>
+      )}
+    </div>
+  );
+};
+
+type FlagOverrideFieldProps = {
+  label: string;
+  description?: string;
+  originalValue?: boolean;
+  overrideValue?: boolean;
+  onOverrideChange: (value: boolean | undefined) => void;
+};
+
+export const FlagOverrideField = ({
+  label,
+  description,
+  originalValue,
+  overrideValue,
+  onOverrideChange,
+}: FlagOverrideFieldProps) => {
+  const original = !!originalValue;
+  const effective = overrideValue ?? original;
+  const isOverridden =
+    overrideValue !== undefined && overrideValue !== original;
+
+  const handleChange = () => {
+    const next = !effective;
+    onOverrideChange(next === original ? undefined : next);
+  };
+
+  const checkbox = (
+    <Checkbox
+      size="sm"
+      checked={effective}
+      label={
+        <span>
+          {label}
+          {isOverridden && (
+            <Tooltip
+              label={t`Reset to Original Value (${original ? t`Yes` : t`No`})`}
+              position="top-end"
+              withArrow
+            >
+              <ActionIcon
+                display="inline-block"
+                ml={4}
+                style={{ verticalAlign: "middle" }}
+              >
+                <RxReset
+                  size={14}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onOverrideChange(undefined);
+                  }}
+                  color="#FFFF00"
+                />
+              </ActionIcon>
+            </Tooltip>
+          )}
+        </span>
+      }
+      description={description}
+      onChange={handleChange}
+      mt={5}
+      mb={5}
+    />
+  );
+
+  return isOverridden ? (
+    <Indicator zIndex="3" color="#FFFF00" position="top-start">
+      {checkbox}
+    </Indicator>
+  ) : (
+    checkbox
+  );
+};
+
+/**
+ *
+ * The store-connected per-asset risk parameter editor (#16).
+ *
+ */
+
+type RiskParamsEditorProps = {
+  assetSymbol: string;
+  assetType: "RESERVE" | "BORROW";
+};
+
+export const RiskParamsEditor = ({
+  assetSymbol,
+  assetType,
+}: RiskParamsEditorProps) => {
+  const {
+    addressData,
+    currentMarket,
+    riskOverrides,
+    effectiveRiskOverrides,
+    setAssetRiskOverride,
+    setEModeCategoryRiskOverride,
+    clearEModeCategoryRiskOverride,
+  } = useAaveData("", true);
+
+  const marketData = addressData?.[currentMarket];
+  const workingData = marketData?.workingData;
+
+  const item =
+    assetType === "RESERVE"
+      ? workingData?.userReservesData?.find(
+        (r) => r.asset.symbol === assetSymbol
+      )
+      : workingData?.userBorrowsData?.find(
+        (b) => b.asset.symbol === assetSymbol
+      );
+
+  if (!item) return null;
+
+  const asset: AssetDetails = item.asset;
+  const override = effectiveRiskOverrides?.assets?.[assetSymbol] || {};
+
+  const userEmodeCategoryId = workingData?.userEmodeCategoryId || 0;
+  const eModes = workingData?.eModes;
+  const activeCategory = userEmodeCategoryId
+    ? eModes?.find((c) => c.id === userEmodeCategoryId)
+    : undefined;
+  const isEModeCollateral = !!asset.isEModeCollateral;
+  const categoryOverride = activeCategory
+    ? effectiveRiskOverrides?.eModeCategories?.[String(activeCategory.id)]
+    : undefined;
+
+  const usesLegacyEMode =
+    !activeCategory &&
+    !!userEmodeCategoryId &&
+    asset.eModeCategoryId === userEmodeCategoryId;
+
+  const setField = (
+    field: string,
+    value: number | boolean | undefined
+  ) => {
+    setAssetRiskOverride(assetSymbol, { [field]: value });
+  };
+
+  const hfOriginal = marketData?.fetchedData?.healthFactor;
+  const hfCurrent = workingData?.healthFactor;
+  const hfDiffers =
+    (hfOriginal || 0) > -1 &&
+    hfOriginal?.toFixed(2) !== hfCurrent?.toFixed(2);
+
+  return (
+    <div>
+      <Text size="sm" c="dimmed" mb="xs">
+        <Trans>
+          Simulate governance changes to this asset's risk parameters. Edits
+          only affect this simulation, never the live protocol.
+        </Trans>
+      </Text>
+
+      {assetType === "RESERVE" && (
+        <>
+          <Group grow align="flex-start" mb="xs">
+            <PercentOverrideField
+              label={t`Max LTV`}
+              originalBps={asset.baseLTVasCollateral}
+              overrideBps={override.ltv}
+              onOverrideChange={(bps) => setField("ltv", bps)}
+              inactiveHint={
+                isEModeCollateral
+                  ? t`Not currently in effect: E-Mode category values apply to this asset.`
+                  : undefined
+              }
+            />
+            <PercentOverrideField
+              label={t`Liquidation Threshold`}
+              originalBps={asset.reserveLiquidationThreshold}
+              overrideBps={override.liquidationThreshold}
+              onOverrideChange={(bps) =>
+                setField("liquidationThreshold", bps)
+              }
+              inactiveHint={
+                isEModeCollateral
+                  ? t`Not currently in effect: E-Mode category values apply to this asset.`
+                  : undefined
+              }
+            />
+          </Group>
+
+          {activeCategory && isEModeCollateral && (
+            <>
+              <Divider
+                label={
+                  <Text size="xs">
+                    <FaBolt />{" "}
+                    <Trans>
+                      E-Mode: {formatEModeLabel(activeCategory.label) ||
+                        activeCategory.id}
+                    </Trans>
+                  </Text>
+                }
+                mb={8}
+                mt={8}
+                labelPosition="center"
+              />
+              <Text size="xs" c="dimmed" mb="xs">
+                <Trans>
+                  This asset is E-Mode collateral, so the E-Mode category's
+                  values apply. Category changes affect every asset in the
+                  category.
+                </Trans>
+              </Text>
+              <Group grow align="flex-start" mb="xs">
+                <PercentOverrideField
+                  label={t`E-Mode Max LTV`}
+                  originalBps={activeCategory.ltv}
+                  overrideBps={categoryOverride?.ltv}
+                  onOverrideChange={(bps) =>
+                    setEModeCategoryRiskOverride(activeCategory.id, {
+                      ltv: bps,
+                    })
+                  }
+                />
+                <PercentOverrideField
+                  label={t`E-Mode Liquidation Threshold`}
+                  originalBps={activeCategory.liquidationThreshold}
+                  overrideBps={categoryOverride?.liquidationThreshold}
+                  onOverrideChange={(bps) =>
+                    setEModeCategoryRiskOverride(activeCategory.id, {
+                      liquidationThreshold: bps,
+                    })
+                  }
+                />
+              </Group>
+            </>
+          )}
+
+          {usesLegacyEMode && (
+            <Group grow align="flex-start" mb="xs">
+              <PercentOverrideField
+                label={t`E-Mode Max LTV`}
+                originalBps={asset.eModeLtv}
+                overrideBps={override.eModeLtv}
+                onOverrideChange={(bps) => setField("eModeLtv", bps)}
+              />
+              <PercentOverrideField
+                label={t`E-Mode Liquidation Threshold`}
+                originalBps={asset.eModeLiquidationThreshold}
+                overrideBps={override.eModeLiquidationThreshold}
+                onOverrideChange={(bps) =>
+                  setField("eModeLiquidationThreshold", bps)
+                }
+              />
+            </Group>
+          )}
+
+          <Group grow align="flex-start" mb="xs">
+            <CapOverrideField
+              label={t`Supply Cap`}
+              description={t`0 means no cap`}
+              originalCap={asset.supplyCap}
+              overrideCap={override.supplyCap}
+              onOverrideChange={(cap) => setField("supplyCap", cap)}
+            />
+          </Group>
+
+          <FlagOverrideField
+            label={t`Usable as Collateral`}
+            description={t`When disabled, this asset stops counting toward borrowing power and health factor.`}
+            originalValue={asset.usageAsCollateralEnabled}
+            overrideValue={override.usageAsCollateralEnabled}
+            onOverrideChange={(value) =>
+              setField("usageAsCollateralEnabled", value)
+            }
+          />
+        </>
+      )}
+
+      {assetType === "BORROW" && (
+        <>
+          <Group grow align="flex-start" mb="xs">
+            <CapOverrideField
+              label={t`Borrow Cap`}
+              description={t`0 means no cap`}
+              originalCap={asset.borrowCap}
+              overrideCap={override.borrowCap}
+              onOverrideChange={(cap) => setField("borrowCap", cap)}
+            />
+          </Group>
+
+          <FlagOverrideField
+            label={t`Borrowing Enabled`}
+            description={t`When disabled, the asset can no longer be newly borrowed.`}
+            originalValue={asset.borrowingEnabled}
+            overrideValue={override.borrowingEnabled}
+            onOverrideChange={(value) => setField("borrowingEnabled", value)}
+          />
+        </>
+      )}
+
+      <FlagOverrideField
+        label={t`Frozen`}
+        description={t`A frozen asset allows no new supplying or borrowing.`}
+        originalValue={asset.isFrozen}
+        overrideValue={override.isFrozen}
+        onOverrideChange={(value) => setField("isFrozen", value)}
+      />
+      <FlagOverrideField
+        label={t`Paused`}
+        description={t`A paused asset allows no interactions at all.`}
+        originalValue={asset.isPaused}
+        overrideValue={override.isPaused}
+        onOverrideChange={(value) => setField("isPaused", value)}
+      />
+
+      {hfDiffers && (
+        <Text size="sm" ta="center" mt="md">
+          <Trans>Health Factor</Trans>
+          {": "}
+          <Text span c="dimmed">
+            {formatNumber(Math.max(hfOriginal || 0, 0), 2)} ➔{" "}
+          </Text>
+          <Mark color={getHealthFactorColor(hfCurrent || 0)}>
+            <Text span pl="2px" pr="2px">
+              {hfCurrent === Infinity
+                ? "∞"
+                : formatNumber(Math.max(hfCurrent || 0, 0), 2)}
+            </Text>
+          </Mark>
+        </Text>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Row-level entry point: a "tune" icon that opens the risk parameter editor
+ * in a modal. Shows a yellow indicator when the asset has active overrides.
+ */
+type RiskParamsDialogProps = {
+  assetSymbol: string;
+  assetType: "RESERVE" | "BORROW";
+};
+
+export const RiskParamsDialog = ({
+  assetSymbol,
+  assetType,
+}: RiskParamsDialogProps) => {
+  const [open, setOpen] = React.useState(false);
+  const { addressData, currentMarket, effectiveRiskOverrides } = useAaveData(
+    "",
+    true
+  );
+
+  const workingData = addressData?.[currentMarket]?.workingData;
+  const item =
+    assetType === "RESERVE"
+      ? workingData?.userReservesData?.find(
+        (r) => r.asset.symbol === assetSymbol
+      )
+      : workingData?.userBorrowsData?.find(
+        (b) => b.asset.symbol === assetSymbol
+      );
+
+  if (!item) return null;
+
+  const assetOverride = effectiveRiskOverrides?.assets?.[assetSymbol];
+  const categoryId = item.asset.isEModeCollateral
+    ? workingData?.userEmodeCategoryId
+    : undefined;
+  const categoryOverridden =
+    categoryId !== undefined &&
+    !!effectiveRiskOverrides?.eModeCategories?.[String(categoryId)];
+  const hasOverride =
+    (assetOverride && Object.keys(assetOverride).length > 0) ||
+    categoryOverridden;
+
+  const icon = (
+    <ActionIcon>
+      <TbAdjustmentsHorizontal
+        title={t`Edit ${assetSymbol} Risk Parameters`}
+        size={16}
+        color={hasOverride ? "#FFFF00" : undefined}
+        onClick={() => setOpen(true)}
+      />
+    </ActionIcon>
+  );
+
+  return (
+    <>
+      <Modal
+        size="lg"
+        opened={open}
+        onClose={() => setOpen(false)}
+        title={t`${assetSymbol} Risk Parameters`}
+      >
+        <RiskParamsEditor assetSymbol={assetSymbol} assetType={assetType} />
+        <Group position="center" mt="lg">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {t`Done`}
+          </Button>
+        </Group>
+      </Modal>
+      <Tooltip
+        label={t`Edit ${assetSymbol} Risk Parameters`}
+        position="right"
+        withArrow
+      >
+        {hasOverride ? (
+          <Indicator zIndex={3} color="#FFFF00" size={6}>
+            {icon}
+          </Indicator>
+        ) : (
+          icon
+        )}
+      </Tooltip>
+    </>
+  );
+};
+
+/**
+ * Warning badge shown when the simulated position exceeds a (possibly
+ * overridden) supply or borrow cap. Caps never change health-factor math;
+ * they gate protocol actions, so surface them as warnings.
+ */
+type AssetCapWarningProps = {
+  assetSymbol: string;
+  assetType: "RESERVE" | "BORROW";
+};
+
+export const AssetCapWarning = ({
+  assetSymbol,
+  assetType,
+}: AssetCapWarningProps) => {
+  const { addressData, currentMarket, effectiveRiskOverrides } = useAaveData(
+    "",
+    true
+  );
+
+  const workingData = addressData?.[currentMarket]?.workingData;
+  const override = effectiveRiskOverrides?.assets?.[assetSymbol];
+
+  let quantity = 0;
+  let cap: number | undefined;
+  if (assetType === "RESERVE") {
+    const item = workingData?.userReservesData?.find(
+      (r) => r.asset.symbol === assetSymbol
+    );
+    if (!item) return null;
+    quantity = item.underlyingBalance;
+    cap = override?.supplyCap ?? item.asset.supplyCap;
+  } else {
+    const item = workingData?.userBorrowsData?.find(
+      (b) => b.asset.symbol === assetSymbol
+    );
+    if (!item) return null;
+    quantity = item.totalBorrows;
+    cap = override?.borrowCap ?? item.asset.borrowCap;
+  }
+
+  if (!cap || cap <= 0 || quantity <= cap) return null;
+
+  const label =
+    assetType === "RESERVE"
+      ? t`The simulated quantity (${formatNumber(
+        quantity
+      )}) exceeds the ${assetSymbol} supply cap (${formatNumber(cap)}).`
+      : t`The simulated quantity (${formatNumber(
+        quantity
+      )}) exceeds the ${assetSymbol} borrow cap (${formatNumber(cap)}).`;
+
+  return (
+    <Tooltip label={label} withArrow multiline width={260}>
+      <Badge
+        color="yellow"
+        variant="outline"
+        size="sm"
+        leftSection={<FiAlertTriangle size={10} />}
+      >
+        {assetType === "RESERVE" ? (
+          <Trans>Exceeds supply cap</Trans>
+        ) : (
+          <Trans>Exceeds borrow cap</Trans>
+        )}
+      </Badge>
+    </Tooltip>
+  );
+};
+
+/**
+ * Position-level indicator that risk parameter overrides are active.
+ * Lists each override with its original value; offers clear-all.
+ */
+export const RiskOverridesChip = () => {
+  const {
+    addressData,
+    currentMarket,
+    effectiveRiskOverrides,
+    riskOverrides,
+    clearAllRiskOverrides,
+  } = useAaveData("", true);
+
+  const marketData = addressData?.[currentMarket];
+  const entries = flattenRiskOverrides(effectiveRiskOverrides);
+
+  if (!entries.length) return null;
+
+  const knownAssets = getKnownAssets(marketData);
+  const eModes = marketData?.workingData?.eModes as
+    | EModeCategoryData[]
+    | undefined;
+  const hasManualOverrides = hasAnyRiskOverrides(riskOverrides);
+
+  return (
+    <Popover width="300px" position="bottom" withArrow shadow="md">
+      <Popover.Target>
+        <Tooltip
+          label={t`Simulated risk parameter changes are active`}
+          position="top-end"
+          withArrow
+        >
+          <ActionIcon style={{ display: "inline-block" }}>
+            <TbAdjustmentsHorizontal size={18} color="#FFFF00" />
+          </ActionIcon>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Text size="sm" fw={700} mb="xs">
+          <Trans>Simulated Risk Parameters</Trans>
+        </Text>
+        <ScrollArea.Autosize mah={220}>
+          {entries.map((entry) => {
+            const original = resolveOriginalRiskFieldValue(
+              entry,
+              knownAssets,
+              eModes
+            );
+            const category = eModes?.find(
+              (c) => String(c.id) === entry.key
+            );
+            const keyLabel =
+              entry.kind === "asset"
+                ? entry.key
+                : t`E-Mode: ${formatEModeLabel(category?.label) || entry.key}`;
+            return (
+              <Text
+                size="xs"
+                key={`${entry.kind}-${entry.key}-${entry.field}`}
+                mb={4}
+              >
+                <Text span fw={600}>
+                  {keyLabel}
+                </Text>
+                {" — "}
+                {getRiskFieldLabel(entry.field)}
+                {": "}
+                {original !== undefined && (
+                  <Text span c="dimmed">
+                    {formatRiskFieldValue(entry.field, original)} ➔{" "}
+                  </Text>
+                )}
+                <Text span fw={600}>
+                  {formatRiskFieldValue(entry.field, entry.value)}
+                </Text>
+              </Text>
+            );
+          })}
+        </ScrollArea.Autosize>
+        {hasManualOverrides && (
+          <Group position="center" mt="sm">
+            <Button
+              variant="subtle"
+              color="gray"
+              compact
+              onClick={clearAllRiskOverrides}
+            >
+              <Trans>Clear all risk parameter changes</Trans>
+            </Button>
+          </Group>
+        )}
+      </Popover.Dropdown>
+    </Popover>
+  );
+};

--- a/hooks/useAaveData.ts
+++ b/hooks/useAaveData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useHookstate, State } from "@hookstate/core";
 import * as pools from "@bgd-labs/aave-address-book";
 
@@ -11,8 +11,20 @@ import {
   EModeCategoryData,
   resolveEffectiveRiskParams,
 } from "../utils/liquidEMode";
+import {
+  AssetRiskOverride,
+  EModeCategoryOverride,
+  RiskParamOverrides,
+  SharedRiskConfig,
+  applyEModeCategoryOverrides,
+  createEmptyRiskOverrides,
+  hasAnyRiskOverrides,
+  mergeRiskOverrides,
+  sanitizeRiskOverrides,
+} from "../utils/riskOverrides";
 
 export type { EModeCategoryData };
+export type { RiskParamOverrides, SharedRiskConfig };
 
 export type HealthFactorData = {
   address: string; // e.g. 0xc...123a or stani.eth
@@ -321,6 +333,19 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
   const addressProvided: boolean = !!(address && address?.length > 0);
   if (address?.length === 0 || address === "DEBUG") address = currentAddress || "";
 
+  const riskOverrides: RiskParamOverrides | undefined =
+    state.riskOverrides?.[address]?.[currentMarket];
+  const sharedRiskConfig: SharedRiskConfig | null =
+    state.sharedRiskConfig ?? null;
+  const sharedRiskConfigEnabled: boolean = !!state.sharedRiskConfigEnabled;
+
+  const effectiveRiskOverrides: RiskParamOverrides = mergeRiskOverrides(
+    sharedRiskConfigEnabled && sharedRiskConfig?.marketId === currentMarket
+      ? sharedRiskConfig.overrides
+      : undefined,
+    riskOverrides
+  );
+
   const isLoadingAny = !!markets.find(
     (market) => data?.[market.id]?.isFetching === true
   );
@@ -433,6 +458,36 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
       }
     }
   }, [isFetching]);
+
+  // Reconcile risk parameter overrides with derived position data. Overrides
+  // are applied at recompute time (never baked into fetched values), so this
+  // recomputes whenever the effective override set changes (including back to
+  // empty, which restores on-chain parameters) or freshly-fetched market data
+  // needs overrides applied.
+  const effectiveOverridesKey = JSON.stringify(effectiveRiskOverrides);
+  const currentMarketLastFetched = data?.[currentMarket]?.lastFetched || 0;
+  const hasWorkingData = !!data?.[currentMarket]?.workingData;
+  const lastAppliedOverridesKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!hasWorkingData) {
+      lastAppliedOverridesKeyRef.current = null;
+      return;
+    }
+    const overridesPresent = hasAnyRiskOverrides(effectiveRiskOverrides);
+    const keyChanged =
+      lastAppliedOverridesKeyRef.current !== null &&
+      lastAppliedOverridesKeyRef.current !== effectiveOverridesKey;
+    lastAppliedOverridesKeyRef.current = effectiveOverridesKey;
+    if (overridesPresent || keyChanged) {
+      updateAllDerivedHealthFactorData();
+    }
+  }, [
+    effectiveOverridesKey,
+    currentMarketLastFetched,
+    currentMarket,
+    hasWorkingData,
+  ]);
 
   const createInitial = (market: AaveMarketDataType) => {
     const hf: HealthFactorData = {
@@ -574,9 +629,11 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
   };
 
   const applyLiquidationScenario = () => {
+    const overrides = getEffectiveRiskOverridesFresh();
     const liquidationScenario = getCalculatedLiquidationScenario(
       data?.[currentMarket]?.workingData as AaveHealthFactorData,
-      data?.[currentMarket]?.marketReferenceCurrencyPriceInUSD
+      data?.[currentMarket]?.marketReferenceCurrencyPriceInUSD,
+      hasAnyRiskOverrides(overrides) ? overrides : undefined
     ) as AssetDetails[];
     liquidationScenario?.forEach((asset) =>
       setAssetPriceInUSD(asset.symbol, asset.priceInUSD)
@@ -602,6 +659,156 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
     store.currentAddress.set(address);
   };
 
+  /**
+   * Effective overrides read fresh from the store (not the render closure),
+   * so recomputes triggered inside mutators always see the latest values.
+   */
+  const getEffectiveRiskOverridesFresh = (): RiskParamOverrides => {
+    const freshState = store.get({ noproxy: true });
+    const manual = freshState.riskOverrides?.[address]?.[currentMarket];
+    const shared =
+      freshState.sharedRiskConfigEnabled &&
+        freshState.sharedRiskConfig?.marketId === currentMarket
+        ? freshState.sharedRiskConfig.overrides
+        : undefined;
+    return mergeRiskOverrides(shared, manual);
+  };
+
+  const setManualRiskOverrides = (
+    updater: (prev: RiskParamOverrides) => RiskParamOverrides
+  ) => {
+    const all = store.riskOverrides.get({ noproxy: true }) || {};
+    const prev: RiskParamOverrides = all?.[address]?.[currentMarket]
+      ? JSON.parse(JSON.stringify(all[address][currentMarket]))
+      : createEmptyRiskOverrides();
+    const next = updater(prev);
+
+    store.riskOverrides.set((current) => {
+      const draft = { ...(current || {}) };
+      const byMarket = { ...(draft[address] || {}) };
+      if (hasAnyRiskOverrides(next)) {
+        byMarket[currentMarket] = next;
+      } else {
+        delete byMarket[currentMarket];
+      }
+      if (Object.keys(byMarket).length) {
+        draft[address] = byMarket;
+      } else {
+        delete draft[address];
+      }
+      return draft;
+    });
+
+    updateAllDerivedHealthFactorData();
+  };
+
+  /**
+   * Set (or update fields of) the simulated risk parameter override for an
+   * asset in the current market. Passing `undefined` for a field removes
+   * that field's override; an entry with no remaining fields is dropped.
+   */
+  const setAssetRiskOverride = (
+    symbol: string,
+    override: Partial<AssetRiskOverride>
+  ) => {
+    setManualRiskOverrides((prev) => {
+      const existing: Record<string, number | boolean | undefined> = {
+        ...(prev.assets[symbol] || {}),
+      };
+      Object.entries(override).forEach(([field, value]) => {
+        if (value === undefined) {
+          delete existing[field];
+        } else {
+          existing[field] = value;
+        }
+      });
+      return sanitizeRiskOverrides({
+        ...prev,
+        assets: { ...prev.assets, [symbol]: existing },
+      });
+    });
+  };
+
+  /** Remove all simulated risk parameter overrides for an asset. */
+  const clearAssetRiskOverride = (symbol: string) => {
+    setManualRiskOverrides((prev) => {
+      const assets = { ...prev.assets };
+      delete assets[symbol];
+      return { ...prev, assets };
+    });
+  };
+
+  /**
+   * Set (or update fields of) the simulated override for an eMode category.
+   * Category LTV/LT apply to every asset that is collateral in the category.
+   */
+  const setEModeCategoryRiskOverride = (
+    categoryId: number,
+    override: Partial<EModeCategoryOverride>
+  ) => {
+    setManualRiskOverrides((prev) => {
+      const existing: Record<string, number | undefined> = {
+        ...(prev.eModeCategories?.[String(categoryId)] || {}),
+      };
+      Object.entries(override).forEach(([field, value]) => {
+        if (value === undefined) {
+          delete existing[field];
+        } else {
+          existing[field] = value;
+        }
+      });
+      return sanitizeRiskOverrides({
+        ...prev,
+        eModeCategories: {
+          ...(prev.eModeCategories || {}),
+          [String(categoryId)]: existing,
+        },
+      });
+    });
+  };
+
+  /** Remove the simulated override for an eMode category. */
+  const clearEModeCategoryRiskOverride = (categoryId: number) => {
+    setManualRiskOverrides((prev) => {
+      const eModeCategories = { ...(prev.eModeCategories || {}) };
+      delete eModeCategories[String(categoryId)];
+      return { ...prev, eModeCategories };
+    });
+  };
+
+  /** Remove all manual risk parameter overrides for the current market. */
+  const clearAllRiskOverrides = () => {
+    setManualRiskOverrides(() => createEmptyRiskOverrides());
+  };
+
+  /**
+   * Install (or remove, with null) a shared risk config decoded from a URL.
+   * Selects the config's market so its effect is immediately visible.
+   */
+  const setSharedRiskConfig = (
+    config: SharedRiskConfig | null,
+    enabled: boolean = true
+  ) => {
+    store.sharedRiskConfig.set(
+      config ? JSON.parse(JSON.stringify(config)) : null
+    );
+    store.sharedRiskConfigEnabled.set(enabled);
+    if (config && store.currentMarket.get() !== config.marketId) {
+      store.currentMarket.set(config.marketId);
+    }
+    // The override reconciliation effect recomputes derived data once the
+    // config's market data is available.
+  };
+
+  /** Toggle whether the shared config is applied to the simulation. */
+  const setSharedRiskConfigEnabled = (enabled: boolean) => {
+    if (store.sharedRiskConfigEnabled.get() === enabled) return;
+    store.sharedRiskConfigEnabled.set(enabled);
+    if (data?.[currentMarket]?.workingData) {
+      updateAllDerivedHealthFactorData();
+    }
+  };
+
   const updateAllDerivedHealthFactorData = () => {
     const currentMarketReferenceCurrencyPriceInUSD: number = store.addressData
       .nested(address)
@@ -615,10 +822,13 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
       noproxy: true,
     }) as AaveHealthFactorData;
 
+    const overrides = getEffectiveRiskOverridesFresh();
+
     const updatedWorkingData: AaveHealthFactorData =
       updateDerivedHealthFactorData(
         workingData,
-        currentMarketReferenceCurrencyPriceInUSD
+        currentMarketReferenceCurrencyPriceInUSD,
+        hasAnyRiskOverrides(overrides) ? overrides : undefined
       );
 
     healthFactorItem.workingData.set(updatedWorkingData);
@@ -643,6 +853,17 @@ export function useAaveData(address: string, preventFetch: boolean = false) {
     setAssetPriceInUSD,
     applyLiquidationScenario,
     setUseReserveAssetAsCollateral,
+    riskOverrides,
+    effectiveRiskOverrides,
+    sharedRiskConfig,
+    sharedRiskConfigEnabled,
+    setAssetRiskOverride,
+    clearAssetRiskOverride,
+    setEModeCategoryRiskOverride,
+    clearEModeCategoryRiskOverride,
+    clearAllRiskOverrides,
+    setSharedRiskConfig,
+    setSharedRiskConfigEnabled,
   };
 }
 
@@ -768,11 +989,15 @@ export const getEligibleLiquidationScenarioReserves = (
  * availableBorrowsUSD
  *
  * @param hfData the healthFactorData to update
+ * @param currentMarketReferenceCurrencyPriceInUSD the market reference currency price
+ * @param riskOverrides optional simulated risk parameter overrides, applied at
+ *   compute time (never written into the position data itself)
  * @returns hfData the updated healthFactorData
  */
 export const updateDerivedHealthFactorData = (
   data: AaveHealthFactorData,
-  currentMarketReferenceCurrencyPriceInUSD: number
+  currentMarketReferenceCurrencyPriceInUSD: number,
+  riskOverrides?: RiskParamOverrides
 ) => {
   let updatedCurrentLiquidationThreshold: BigNumber = new BigNumber(0);
   let updatedCurrentLoanToValue: BigNumber = new BigNumber(0);
@@ -787,6 +1012,13 @@ export const updateDerivedHealthFactorData = (
   let weightedReservesETH: BigNumber = new BigNumber(0);
   let weightedLTVETH: BigNumber = new BigNumber(0);
   let totalBorrowsETH: BigNumber = new BigNumber(0);
+
+  // eMode category overrides apply to the categories themselves (governance
+  // changes them category-wide), so resolve them once up front.
+  const effectiveEModes = applyEModeCategoryOverrides(
+    data.eModes,
+    riskOverrides
+  );
 
   data.userReservesData.forEach((reserveItem) => {
     const underlyingBalance: BigNumber = new BigNumber(
@@ -834,25 +1066,41 @@ export const updateDerivedHealthFactorData = (
       reserveItem.underlyingBalanceUSD = updatedUnderlyingBalanceUSD.toNumber();
     }
 
+    // Resolve effective risk params (with any simulated overrides applied)
+    // for every reserve so display stays consistent even for non-collateral
+    // assets.
+    const assetOverride = riskOverrides?.assets?.[reserveItem.asset.symbol];
+
+    const risk = resolveEffectiveRiskParams({
+      userEmodeCategoryId: data.userEmodeCategoryId,
+      eModes: effectiveEModes,
+      reserveId: reserveItem.asset.reserveId,
+      baseLtv:
+        assetOverride?.ltv ?? (reserveItem.asset.baseLTVasCollateral || 0),
+      baseLiquidationThreshold:
+        assetOverride?.liquidationThreshold ??
+        (reserveItem.asset.reserveLiquidationThreshold || 0),
+      legacyEModeCategoryId: reserveItem.asset.eModeCategoryId,
+      legacyEModeLtv: assetOverride?.eModeLtv ?? reserveItem.asset.eModeLtv,
+      legacyEModeLiquidationThreshold:
+        assetOverride?.eModeLiquidationThreshold ??
+        reserveItem.asset.eModeLiquidationThreshold,
+    });
+    reserveItem.asset.effectiveLtv = risk.ltv;
+    reserveItem.asset.effectiveLiquidationThreshold = risk.liquidationThreshold;
+    reserveItem.asset.isEModeCollateral = risk.isEMode;
+
+    // An override can simulate the reserve being disabled as collateral
+    // market-wide (e.g. a governance action), which drops its contribution
+    // regardless of the user-level collateral toggle.
+    const collateralDisabledByOverride =
+      assetOverride?.usageAsCollateralEnabled === false;
+
     // Update the necessary accumulated values for updating healthFactor etc.
-    if (reserveItem.usageAsCollateralEnabledOnUser) {
+    if (reserveItem.usageAsCollateralEnabledOnUser && !collateralDisabledByOverride) {
       updatedCollateral = updatedCollateral.plus(
         updatedUnderlyingBalanceMarketReferenceCurrency
       );
-
-      const risk = resolveEffectiveRiskParams({
-        userEmodeCategoryId: data.userEmodeCategoryId,
-        eModes: data.eModes,
-        reserveId: reserveItem.asset.reserveId,
-        baseLtv: reserveItem.asset.baseLTVasCollateral || 0,
-        baseLiquidationThreshold: reserveItem.asset.reserveLiquidationThreshold || 0,
-        legacyEModeCategoryId: reserveItem.asset.eModeCategoryId,
-        legacyEModeLtv: reserveItem.asset.eModeLtv,
-        legacyEModeLiquidationThreshold: reserveItem.asset.eModeLiquidationThreshold,
-      });
-      reserveItem.asset.effectiveLtv = risk.ltv;
-      reserveItem.asset.effectiveLiquidationThreshold = risk.liquidationThreshold;
-      reserveItem.asset.isEModeCollateral = risk.isEMode;
 
       const itemReserveLiquidationThreshold: BigNumber = new BigNumber(
         risk.liquidationThreshold
@@ -1025,7 +1273,8 @@ export const updateDerivedHealthFactorData = (
  */
 export const getCalculatedLiquidationScenario = (
   hfData: AaveHealthFactorData,
-  currentMarketReferenceCurrencyPriceInUSD: number
+  currentMarketReferenceCurrencyPriceInUSD: number,
+  riskOverrides?: RiskParamOverrides
 ) => {
   if (!hfData) return [];
   // deep clone to avoid mutating state
@@ -1086,7 +1335,8 @@ export const getCalculatedLiquidationScenario = (
 
       const updatedWorkingData = updateDerivedHealthFactorData(
         hfData,
-        currentMarketReferenceCurrencyPriceInUSD
+        currentMarketReferenceCurrencyPriceInUSD,
+        riskOverrides
       );
 
       hf = updatedWorkingData.healthFactor;
@@ -1153,7 +1403,8 @@ export const getCalculatedLiquidationScenario = (
 
       const updatedWorkingData = updateDerivedHealthFactorData(
         hfData,
-        currentMarketReferenceCurrencyPriceInUSD
+        currentMarketReferenceCurrencyPriceInUSD,
+        riskOverrides
       );
 
       if (updatedWorkingData.healthFactor < 1.0) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,21 +19,24 @@ import { NextRouter, useRouter } from "next/router";
 import { ethers } from "ethers";
 import { Trans, t } from "@lingui/macro";
 
-import { useAaveData } from "../hooks/useAaveData";
+import { useAaveData, markets } from "../hooks/useAaveData";
+import { decodeRiskConfig } from "../utils/riskOverrides";
 import AppBar from "../components/AppBar";
 import AddressInput, { isValidENSAddress } from "../components/AddressInput";
 import AddressCard from "../components/AddressCard";
+import ConfigBanner from "../components/ConfigBanner";
 import Footer from "../components/Footer";
 import { activateLocale } from "./_app";
 
 export default function HomePage() {
   const router: NextRouter = useRouter();
   const address = router?.query?.address as string;
+  const configParam = router?.query?.config as string;
   const isValidAddress: boolean =
     ethers.utils.isAddress(address) || isValidENSAddress(address);
-  const { currentAddress, setCurrentAddress } = useAaveData(
-    isValidAddress ? address : ""
-  );
+  const { currentAddress, setCurrentAddress, setSharedRiskConfig } =
+    useAaveData(isValidAddress ? address : "");
+  const [configInvalid, setConfigInvalid] = useState(false);
 
   const locale = router?.locale;
 
@@ -50,12 +53,48 @@ export default function HomePage() {
   }, [address]);
 
   useEffect(() => {
+    // apply a shared risk parameter config from the url, if present
+    if (!router.isReady || !configParam) return;
+    const decoded = decodeRiskConfig(
+      configParam,
+      markets.map((market) => market.id)
+    );
+    if (decoded) {
+      setConfigInvalid(false);
+      setSharedRiskConfig(decoded);
+    } else {
+      // Malformed/unknown payload: surface a notice and drop the param.
+      setConfigInvalid(true);
+      const { config, ...remainingQuery } = router.query;
+      router.replace({ query: remainingQuery }, undefined, { shallow: true });
+    }
+  }, [router.isReady, configParam]);
+
+  useEffect(() => {
     // ensure current locale is correctly set from url
     if (locale) activateLocale(locale);
   }, [locale]);
 
   return (
     <Container px="xs" style={{ contain: "paint" }}>
+      <ConfigBanner />
+      {configInvalid && (
+        <Alert
+          mt={15}
+          icon={<FiAlertTriangle size="1rem" />}
+          title={<Trans>Invalid Config Link</Trans>}
+          color="red"
+          variant="outline"
+          withCloseButton
+          onClose={() => setConfigInvalid(false)}
+          closeButtonLabel={t`Close alert`}
+        >
+          <Trans>
+            The risk parameter config in this link could not be read, so it
+            was ignored. Ask the sender for a fresh link.
+          </Trans>
+        </Alert>
+      )}
       <AppBar />
       <AddressInput />
       {currentAddress && <AddressCard />}

--- a/store/healthFactorDataStore.ts
+++ b/store/healthFactorDataStore.ts
@@ -1,17 +1,30 @@
 import React from "react";
 import { hookstate, State } from "@hookstate/core";
 import { HealthFactorData } from "../hooks/useAaveData";
+import {
+  RiskParamOverrides,
+  SharedRiskConfig,
+} from "../utils/riskOverrides";
 
 interface HealthFactorStore {
   currentAddress: string;
   currentMarket: string;
   addressData: Record<string, Record<string, HealthFactorData>>;
+  /** Manual per-asset risk parameter overrides, keyed by address then market */
+  riskOverrides: Record<string, Record<string, RiskParamOverrides>>;
+  /** A shared risk config decoded from a `?config=` URL, if any */
+  sharedRiskConfig: SharedRiskConfig | null;
+  /** Whether the shared config is currently applied to the simulation */
+  sharedRiskConfigEnabled: boolean;
 }
 
 const defaultState: HealthFactorStore = {
   currentAddress: "",
   currentMarket: "ETHEREUM_V3",
   addressData: {},
+  riskOverrides: {},
+  sharedRiskConfig: null,
+  sharedRiskConfigEnabled: true,
 };
 
 export const HealthFactorDataStore: HealthFactorStore = hookstate(defaultState);

--- a/test/hooks/riskOverridesSim.test.ts
+++ b/test/hooks/riskOverridesSim.test.ts
@@ -1,0 +1,525 @@
+import { expect } from "@jest/globals";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  useAaveData,
+  updateDerivedHealthFactorData,
+  AaveHealthFactorData,
+  AssetDetails,
+} from "../../hooks/useAaveData";
+import { HealthFactorDataStore } from "../../store/healthFactorDataStore";
+import {
+  sanitizeRiskOverrides,
+  RiskParamOverrides,
+} from "../../utils/riskOverrides";
+import { getAaveData } from "../../pages/api/aave";
+
+// The hook calls getAaveData directly (not the /api/aave route), so mock the
+// module. The factory avoids loading the real implementation, which pulls in
+// ethers providers and other heavy server-side dependencies.
+jest.mock("../../pages/api/aave", () => ({
+  getAaveData: jest.fn(),
+}));
+
+const mockGetAaveData = getAaveData as jest.Mock;
+
+const PRECISION = 6;
+const TEST_ADDRESS = "0x1111111111111111111111111111111111111111";
+
+/**
+ * Synthetic position, chosen so expected values are simple to derive
+ * (marketReferenceCurrency == USD):
+ *
+ *   ETH:    10 @ $2000 = $20,000 collateral (LTV 80.00%, LT 82.50%)
+ *   wstETH:  5 @ $2400 = $12,000 collateral (LTV 75.00%, LT 80.00%)
+ *   USDC borrow: $10,000
+ *
+ * Base:   LT weighted  = (0.825*20000 + 0.80*12000) / 32000 = 0.815625
+ *         HF           = 32000 * 0.815625 / 10000        = 2.6100
+ *         availableUSD = 32000 * 0.78125 - 10000         = 15000
+ * E-Mode: (LTV 93.00%, LT 95.00% for both reserves)
+ *         HF           = 32000 * 0.95 / 10000            = 3.0400
+ */
+const makeAsset = (overrides: Partial<AssetDetails>): AssetDetails => ({
+  symbol: "X",
+  name: "X",
+  priceInUSD: 1,
+  priceInMarketReferenceCurrency: 1,
+  baseLTVasCollateral: 0,
+  reserveLiquidationThreshold: 0,
+  reserveFactor: 0,
+  usageAsCollateralEnabled: true,
+  initialPriceInUSD: 1,
+  ...overrides,
+});
+
+type EModeVariant = "none" | "liquid" | "legacy";
+
+const buildPosition = (
+  emode: EModeVariant = "none"
+): AaveHealthFactorData => {
+  const legacyEModeFields =
+    emode === "legacy"
+      ? {
+        eModeCategoryId: 1,
+        eModeLtv: 9300,
+        eModeLiquidationThreshold: 9500,
+      }
+      : {};
+
+  const eth = makeAsset({
+    symbol: "ETH",
+    name: "Ethereum",
+    priceInUSD: 2000,
+    initialPriceInUSD: 2000,
+    baseLTVasCollateral: 8000,
+    reserveLiquidationThreshold: 8250,
+    reserveId: 0,
+    supplyCap: 100,
+    borrowingEnabled: true,
+    isActive: true,
+    ...legacyEModeFields,
+  });
+
+  const wsteth = makeAsset({
+    symbol: "WSTETH",
+    name: "Wrapped stETH",
+    priceInUSD: 2400,
+    initialPriceInUSD: 2400,
+    baseLTVasCollateral: 7500,
+    reserveLiquidationThreshold: 8000,
+    reserveId: 1,
+    borrowingEnabled: false,
+    isActive: true,
+    ...legacyEModeFields,
+  });
+
+  const usdc = makeAsset({
+    symbol: "USDC",
+    name: "USD Coin",
+    priceInUSD: 1,
+    initialPriceInUSD: 1,
+    borrowCap: 50000,
+    borrowingEnabled: true,
+    isActive: true,
+  });
+
+  const data: AaveHealthFactorData = {
+    address: TEST_ADDRESS,
+    healthFactor: 0,
+    totalBorrowsUSD: 0,
+    availableBorrowsUSD: 0,
+    totalCollateralMarketReferenceCurrency: 0,
+    totalBorrowsMarketReferenceCurrency: 0,
+    currentLiquidationThreshold: 0,
+    currentLoanToValue: 0,
+    userReservesData: [
+      {
+        asset: eth,
+        underlyingBalance: 10,
+        underlyingBalanceUSD: 20000,
+        underlyingBalanceMarketReferenceCurrency: 20000,
+        usageAsCollateralEnabledOnUser: true,
+      },
+      {
+        asset: wsteth,
+        underlyingBalance: 5,
+        underlyingBalanceUSD: 12000,
+        underlyingBalanceMarketReferenceCurrency: 12000,
+        usageAsCollateralEnabledOnUser: true,
+      },
+    ],
+    userBorrowsData: [
+      {
+        asset: usdc,
+        totalBorrows: 10000,
+        totalBorrowsUSD: 10000,
+        totalBorrowsMarketReferenceCurrency: 10000,
+        stableBorrowAPY: 0,
+      },
+    ],
+    userEmodeCategoryId: emode === "none" ? 0 : 1,
+  };
+
+  if (emode === "liquid") {
+    data.eModes = [
+      {
+        id: 1,
+        label: "ETH correlated",
+        ltv: 9300,
+        liquidationThreshold: 9500,
+        collateralBitmap: "3", // reserve ids 0 and 1
+        borrowableBitmap: "7",
+      },
+    ];
+  }
+
+  // Make derived fields (HF, LT, availableBorrows...) internally consistent.
+  updateDerivedHealthFactorData(data, 1);
+  return data;
+};
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value));
+
+describe("updateDerivedHealthFactorData with risk overrides", () => {
+  test("base position computes expected values without overrides", () => {
+    const data = buildPosition();
+    expect(data.healthFactor).toBeCloseTo(2.61, PRECISION);
+    expect(data.availableBorrowsUSD).toBeCloseTo(15000, PRECISION);
+    expect(data.currentLiquidationThreshold).toBeCloseTo(0.815625, PRECISION);
+  });
+
+  test("liquidation threshold override changes health factor", () => {
+    const data = clone(buildPosition());
+    const overrides = sanitizeRiskOverrides({
+      assets: { ETH: { liquidationThreshold: 9000 } },
+    });
+
+    updateDerivedHealthFactorData(data, 1, overrides);
+
+    // (0.90*20000 + 0.80*12000) / 10000 = 2.76
+    expect(data.healthFactor).toBeCloseTo(2.76, PRECISION);
+    // per-asset effective values reflect the override
+    const eth = data.userReservesData.find((r) => r.asset.symbol === "ETH");
+    expect(eth?.asset.effectiveLiquidationThreshold).toEqual(9000);
+  });
+
+  test("ltv override changes available borrows but not health factor", () => {
+    const data = clone(buildPosition());
+    const overrides = sanitizeRiskOverrides({
+      assets: { ETH: { ltv: 9000 } },
+    });
+
+    updateDerivedHealthFactorData(data, 1, overrides);
+
+    // (0.90*20000 + 0.75*12000) - 10000 = 17000
+    expect(data.availableBorrowsUSD).toBeCloseTo(17000, PRECISION);
+    expect(data.healthFactor).toBeCloseTo(2.61, PRECISION);
+  });
+
+  test("collateral-disable override drops the asset's contribution", () => {
+    const data = clone(buildPosition());
+    const overrides = sanitizeRiskOverrides({
+      assets: { ETH: { usageAsCollateralEnabled: false } },
+    });
+
+    updateDerivedHealthFactorData(data, 1, overrides);
+
+    // Only wstETH counts: 12000 * 0.80 / 10000 = 0.96
+    expect(data.healthFactor).toBeCloseTo(0.96, PRECISION);
+    expect(data.totalCollateralMarketReferenceCurrency).toBeCloseTo(
+      12000,
+      PRECISION
+    );
+  });
+
+  test("recomputing without overrides restores on-chain values", () => {
+    const data = clone(buildPosition());
+    const overrides = sanitizeRiskOverrides({
+      assets: {
+        ETH: { liquidationThreshold: 9000, usageAsCollateralEnabled: false },
+      },
+    });
+
+    updateDerivedHealthFactorData(data, 1, overrides);
+    expect(data.healthFactor).not.toBeCloseTo(2.61, 2);
+
+    updateDerivedHealthFactorData(data, 1);
+    expect(data.healthFactor).toBeCloseTo(2.61, PRECISION);
+    expect(data.availableBorrowsUSD).toBeCloseTo(15000, PRECISION);
+  });
+
+  describe("liquid e-mode positions", () => {
+    test("e-mode category values apply without overrides", () => {
+      const data = buildPosition("liquid");
+      expect(data.healthFactor).toBeCloseTo(3.04, PRECISION);
+    });
+
+    test("category override wins for e-mode collateral", () => {
+      const data = clone(buildPosition("liquid"));
+      const overrides = sanitizeRiskOverrides({
+        eModeCategories: { "1": { liquidationThreshold: 9000 } },
+      });
+
+      updateDerivedHealthFactorData(data, 1, overrides);
+
+      // 32000 * 0.90 / 10000 = 2.88
+      expect(data.healthFactor).toBeCloseTo(2.88, PRECISION);
+    });
+
+    test("base param override has no effect on e-mode collateral", () => {
+      const data = clone(buildPosition("liquid"));
+      const overrides = sanitizeRiskOverrides({
+        assets: { ETH: { liquidationThreshold: 5000 } },
+      });
+
+      updateDerivedHealthFactorData(data, 1, overrides);
+
+      expect(data.healthFactor).toBeCloseTo(3.04, PRECISION);
+    });
+  });
+
+  describe("legacy e-mode positions", () => {
+    test("legacy e-mode values apply without overrides", () => {
+      const data = buildPosition("legacy");
+      expect(data.healthFactor).toBeCloseTo(3.04, PRECISION);
+    });
+
+    test("per-asset e-mode override applies", () => {
+      const data = clone(buildPosition("legacy"));
+      const overrides = sanitizeRiskOverrides({
+        assets: { ETH: { eModeLiquidationThreshold: 9000 } },
+      });
+
+      updateDerivedHealthFactorData(data, 1, overrides);
+
+      // (0.90*20000 + 0.95*12000) / 10000 = 2.94
+      expect(data.healthFactor).toBeCloseTo(2.94, PRECISION);
+    });
+  });
+});
+
+describe("useAaveData risk override mutators", () => {
+  beforeEach(() => {
+    // Reset the global store so tests don't leak state into one another.
+    const store = HealthFactorDataStore as any;
+    store.addressData.set({});
+    store.currentAddress.set("");
+    store.currentMarket.set("ETHEREUM_V3");
+    store.riskOverrides.set({});
+    store.sharedRiskConfig.set(null);
+    store.sharedRiskConfigEnabled.set(true);
+
+    mockGetAaveData.mockReset();
+    const seed = buildPosition();
+    mockGetAaveData.mockImplementation(async () =>
+      JSON.parse(
+        JSON.stringify({
+          address: TEST_ADDRESS,
+          marketReferenceCurrencyPriceInUSD: 1,
+          fetchedData: seed,
+          workingData: seed,
+          lastFetched: Date.now(),
+        })
+      )
+    );
+  });
+
+  const setup = async () => {
+    const rendered = renderHook(() => useAaveData(TEST_ADDRESS));
+    await waitFor(() => {
+      const data =
+        rendered.result.current.addressData?.[
+        rendered.result.current.currentMarket
+        ];
+      expect(data?.workingData).not.toBeUndefined();
+    });
+    return rendered;
+  };
+
+  const getWorkingData = (result: any) =>
+    result.current.addressData?.[result.current.currentMarket]?.workingData;
+
+  test("setAssetRiskOverride modifies health factor; clearAssetRiskOverride restores it", async () => {
+    const { result } = await setup();
+    const originalHF = getWorkingData(result)?.healthFactor;
+
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", {
+        liquidationThreshold: 9000,
+      });
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(2.76, PRECISION);
+    expect(
+      result.current.addressData?.[result.current.currentMarket]?.fetchedData
+        ?.healthFactor
+    ).toBeCloseTo(originalHF, PRECISION); // fetched data untouched
+
+    act(() => {
+      result.current.clearAssetRiskOverride("ETH");
+    });
+
+    expect(getWorkingData(result)?.healthFactor.toFixed(PRECISION)).toEqual(
+      originalHF.toFixed(PRECISION)
+    );
+    // fully-cleared override entries are pruned from the store
+    expect(result.current.riskOverrides).toBeUndefined();
+  });
+
+  test("ltv override modifies available borrows", async () => {
+    const { result } = await setup();
+
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", { ltv: 9000 });
+    });
+
+    expect(getWorkingData(result)?.availableBorrowsUSD).toBeCloseTo(
+      17000,
+      PRECISION
+    );
+  });
+
+  test("collateral-disable override drops contribution and restores on clear", async () => {
+    const { result } = await setup();
+    const originalHF = getWorkingData(result)?.healthFactor;
+
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", {
+        usageAsCollateralEnabled: false,
+      });
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(0.96, PRECISION);
+
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", {
+        usageAsCollateralEnabled: undefined,
+      });
+    });
+
+    expect(getWorkingData(result)?.healthFactor.toFixed(PRECISION)).toEqual(
+      originalHF.toFixed(PRECISION)
+    );
+  });
+
+  test("clearAllRiskOverrides removes every override", async () => {
+    const { result } = await setup();
+    const originalHF = getWorkingData(result)?.healthFactor;
+
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", {
+        liquidationThreshold: 9000,
+      });
+      result.current.setAssetRiskOverride("WSTETH", { ltv: 5000 });
+    });
+
+    expect(getWorkingData(result)?.healthFactor).not.toBeCloseTo(
+      originalHF,
+      2
+    );
+
+    act(() => {
+      result.current.clearAllRiskOverrides();
+    });
+
+    expect(getWorkingData(result)?.healthFactor.toFixed(PRECISION)).toEqual(
+      originalHF.toFixed(PRECISION)
+    );
+    expect(result.current.riskOverrides).toBeUndefined();
+  });
+
+  test("resetCurrentMarketChanges keeps risk overrides applied (independent reset scopes)", async () => {
+    const { result } = await setup();
+
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", {
+        liquidationThreshold: 9000,
+      });
+    });
+    const overriddenHF = getWorkingData(result)?.healthFactor;
+    expect(overriddenHF).toBeCloseTo(2.76, PRECISION);
+
+    act(() => {
+      result.current.setReserveAssetQuantity("ETH", 20);
+    });
+    expect(getWorkingData(result)?.healthFactor).not.toBeCloseTo(
+      overriddenHF,
+      2
+    );
+
+    act(() => {
+      result.current.resetCurrentMarketChanges();
+    });
+
+    // quantity edit reverted, override still in effect
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(
+      2.76,
+      PRECISION
+    );
+    expect(result.current.riskOverrides).not.toBeUndefined();
+  });
+
+  test("shared config applies, toggles off/on, and merges under manual edits", async () => {
+    const { result } = await setup();
+    const originalHF = getWorkingData(result)?.healthFactor;
+
+    const config = {
+      marketId: result.current.currentMarket,
+      overrides: sanitizeRiskOverrides({
+        assets: { ETH: { liquidationThreshold: 9000 } },
+      }) as RiskParamOverrides,
+    };
+
+    act(() => {
+      result.current.setSharedRiskConfig(config);
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(2.76, PRECISION);
+
+    act(() => {
+      result.current.setSharedRiskConfigEnabled(false);
+    });
+
+    expect(getWorkingData(result)?.healthFactor.toFixed(PRECISION)).toEqual(
+      originalHF.toFixed(PRECISION)
+    );
+
+    act(() => {
+      result.current.setSharedRiskConfigEnabled(true);
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(2.76, PRECISION);
+
+    // manual edits take precedence over the shared config, field by field
+    act(() => {
+      result.current.setAssetRiskOverride("ETH", {
+        liquidationThreshold: 8500,
+      });
+    });
+
+    // (0.85*20000 + 0.80*12000) / 10000 = 2.66
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(2.66, PRECISION);
+
+    // removing the config leaves the manual edit in place
+    act(() => {
+      result.current.setSharedRiskConfig(null);
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(2.66, PRECISION);
+  });
+
+  test("e-mode category override via hook mutator", async () => {
+    const store = HealthFactorDataStore as any;
+    store.addressData.set({});
+    mockGetAaveData.mockReset();
+    const seed = buildPosition("liquid");
+    mockGetAaveData.mockImplementation(async () =>
+      JSON.parse(
+        JSON.stringify({
+          address: TEST_ADDRESS,
+          marketReferenceCurrencyPriceInUSD: 1,
+          fetchedData: seed,
+          workingData: seed,
+          lastFetched: Date.now(),
+        })
+      )
+    );
+
+    const { result } = await setup();
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(3.04, PRECISION);
+
+    act(() => {
+      result.current.setEModeCategoryRiskOverride(1, {
+        liquidationThreshold: 9000,
+      });
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(2.88, PRECISION);
+
+    act(() => {
+      result.current.clearEModeCategoryRiskOverride(1);
+    });
+
+    expect(getWorkingData(result)?.healthFactor).toBeCloseTo(3.04, PRECISION);
+  });
+});

--- a/test/utils/riskOverrides.test.ts
+++ b/test/utils/riskOverrides.test.ts
@@ -1,0 +1,416 @@
+import {
+  applyEModeCategoryOverrides,
+  applyRiskOverridesToAsset,
+  createEmptyRiskOverrides,
+  decodeRiskConfig,
+  encodeRiskConfig,
+  flattenRiskOverrides,
+  hasAnyRiskOverrides,
+  mergeRiskOverrides,
+  sanitizeRiskOverrides,
+  RiskParamOverrides,
+  SharedRiskConfig,
+} from "../../utils/riskOverrides";
+import { EModeCategoryData } from "../../utils/liquidEMode";
+
+describe("sanitizeRiskOverrides", () => {
+  test("passes through valid overrides", () => {
+    const clean = sanitizeRiskOverrides({
+      assets: {
+        WETH: {
+          ltv: 7500,
+          liquidationThreshold: 8000,
+          supplyCap: 100000,
+          isFrozen: true,
+        },
+      },
+      eModeCategories: { "1": { ltv: 9000, liquidationThreshold: 9300 } },
+      meta: { label: "Test config", ref: "https://governance.aave.com/t/x" },
+    });
+
+    expect(clean.assets.WETH).toEqual({
+      ltv: 7500,
+      liquidationThreshold: 8000,
+      supplyCap: 100000,
+      isFrozen: true,
+    });
+    expect(clean.eModeCategories?.["1"]).toEqual({
+      ltv: 9000,
+      liquidationThreshold: 9300,
+    });
+    expect(clean.meta).toEqual({
+      label: "Test config",
+      ref: "https://governance.aave.com/t/x",
+    });
+  });
+
+  test("clamps bps fields to 0..10000 and drops invalid numbers", () => {
+    const clean = sanitizeRiskOverrides({
+      assets: {
+        WETH: { ltv: 999999, liquidationThreshold: -5 },
+        USDC: { supplyCap: NaN, borrowCap: Infinity },
+        DAI: { ltv: "not-a-number" },
+      },
+    });
+
+    expect(clean.assets.WETH).toEqual({ ltv: 10000 });
+    expect(clean.assets.USDC).toBeUndefined();
+    expect(clean.assets.DAI).toBeUndefined();
+  });
+
+  test("enforces liquidation threshold >= ltv when both overridden", () => {
+    const clean = sanitizeRiskOverrides({
+      assets: { WETH: { ltv: 9000, liquidationThreshold: 8000 } },
+      eModeCategories: { "1": { ltv: 9600, liquidationThreshold: 9300 } },
+    });
+
+    expect(clean.assets.WETH).toEqual({
+      ltv: 8000,
+      liquidationThreshold: 8000,
+    });
+    expect(clean.eModeCategories?.["1"]).toEqual({
+      ltv: 9300,
+      liquidationThreshold: 9300,
+    });
+  });
+
+  test("drops unknown fields, bad category ids, and bad meta", () => {
+    const clean = sanitizeRiskOverrides({
+      assets: {
+        WETH: { ltv: 5000, madeUpField: 12345 },
+        "": { ltv: 5000 },
+      },
+      eModeCategories: {
+        "999": { ltv: 9000 },
+        "-1": { ltv: 9000 },
+        abc: { ltv: 9000 },
+        "2": { ltv: 8800 },
+      },
+      meta: { label: "   ", ref: "javascript:alert(1)" },
+    });
+
+    expect(clean.assets.WETH).toEqual({ ltv: 5000 });
+    expect(clean.assets[""]).toBeUndefined();
+    expect(Object.keys(clean.eModeCategories || {})).toEqual(["2"]);
+    expect(clean.meta).toBeUndefined();
+  });
+
+  test("handles garbage input", () => {
+    expect(hasAnyRiskOverrides(sanitizeRiskOverrides(null))).toBe(false);
+    expect(hasAnyRiskOverrides(sanitizeRiskOverrides("junk"))).toBe(false);
+    expect(hasAnyRiskOverrides(sanitizeRiskOverrides(42))).toBe(false);
+    expect(hasAnyRiskOverrides(sanitizeRiskOverrides({ assets: 7 }))).toBe(
+      false
+    );
+  });
+});
+
+describe("hasAnyRiskOverrides", () => {
+  test("false for empty/absent overrides", () => {
+    expect(hasAnyRiskOverrides(undefined)).toBe(false);
+    expect(hasAnyRiskOverrides(null)).toBe(false);
+    expect(hasAnyRiskOverrides(createEmptyRiskOverrides())).toBe(false);
+  });
+
+  test("true when any asset or category override exists", () => {
+    expect(
+      hasAnyRiskOverrides({ v: 1, assets: { WETH: { ltv: 5000 } } })
+    ).toBe(true);
+    expect(
+      hasAnyRiskOverrides({
+        v: 1,
+        assets: {},
+        eModeCategories: { "1": { ltv: 9000 } },
+      })
+    ).toBe(true);
+  });
+});
+
+describe("mergeRiskOverrides", () => {
+  test("priority fields win over base, disjoint fields combine", () => {
+    const base: RiskParamOverrides = {
+      v: 1,
+      assets: {
+        WETH: { ltv: 7000, liquidationThreshold: 7500 },
+        USDC: { borrowCap: 1000 },
+      },
+      eModeCategories: { "1": { ltv: 9000 } },
+      meta: { label: "base" },
+    };
+    const priority: RiskParamOverrides = {
+      v: 1,
+      assets: { WETH: { ltv: 6000 } },
+      eModeCategories: { "1": { liquidationThreshold: 9400 } },
+    };
+
+    const merged = mergeRiskOverrides(base, priority);
+
+    expect(merged.assets.WETH).toEqual({
+      ltv: 6000,
+      liquidationThreshold: 7500,
+    });
+    expect(merged.assets.USDC).toEqual({ borrowCap: 1000 });
+    expect(merged.eModeCategories?.["1"]).toEqual({
+      ltv: 9000,
+      liquidationThreshold: 9400,
+    });
+    expect(merged.meta).toEqual({ label: "base" });
+  });
+
+  test("handles absent inputs", () => {
+    expect(hasAnyRiskOverrides(mergeRiskOverrides(undefined, null))).toBe(
+      false
+    );
+    const merged = mergeRiskOverrides(undefined, {
+      v: 1,
+      assets: { WETH: { ltv: 5000 } },
+    });
+    expect(merged.assets.WETH).toEqual({ ltv: 5000 });
+  });
+});
+
+describe("applyEModeCategoryOverrides", () => {
+  const categories: EModeCategoryData[] = [
+    {
+      id: 1,
+      label: "ETH correlated",
+      ltv: 9300,
+      liquidationThreshold: 9500,
+      collateralBitmap: "3",
+      borrowableBitmap: "4",
+    },
+    {
+      id: 2,
+      label: "Stablecoins",
+      ltv: 9000,
+      liquidationThreshold: 9200,
+      collateralBitmap: "12",
+      borrowableBitmap: "12",
+    },
+  ];
+
+  test("returns input unchanged when no category overrides", () => {
+    expect(applyEModeCategoryOverrides(categories, undefined)).toBe(
+      categories
+    );
+    expect(
+      applyEModeCategoryOverrides(categories, createEmptyRiskOverrides())
+    ).toBe(categories);
+  });
+
+  test("applies overrides without mutating the source", () => {
+    const overrides: RiskParamOverrides = {
+      v: 1,
+      assets: {},
+      eModeCategories: { "1": { liquidationThreshold: 9000 } },
+    };
+    const result = applyEModeCategoryOverrides(categories, overrides) || [];
+
+    expect(result[0].liquidationThreshold).toEqual(9000);
+    expect(result[0].ltv).toEqual(9300);
+    expect(result[1]).toBe(categories[1]);
+    expect(categories[0].liquidationThreshold).toEqual(9500);
+  });
+});
+
+describe("applyRiskOverridesToAsset", () => {
+  const asset = {
+    symbol: "WETH",
+    baseLTVasCollateral: 8000,
+    reserveLiquidationThreshold: 8250,
+    supplyCap: 100,
+    borrowCap: 0,
+    borrowingEnabled: true,
+    usageAsCollateralEnabled: true,
+    isFrozen: false,
+    isPaused: false,
+  };
+
+  test("returns the same object when no override exists", () => {
+    expect(applyRiskOverridesToAsset(asset, undefined)).toBe(asset);
+    expect(
+      applyRiskOverridesToAsset(asset, {
+        v: 1,
+        assets: { USDC: { ltv: 1 } },
+      })
+    ).toBe(asset);
+  });
+
+  test("applies overridden fields, preserves the rest", () => {
+    const overridden = applyRiskOverridesToAsset(asset, {
+      v: 1,
+      assets: {
+        WETH: { liquidationThreshold: 7000, isFrozen: true, supplyCap: 50 },
+      },
+    });
+
+    expect(overridden.reserveLiquidationThreshold).toEqual(7000);
+    expect(overridden.isFrozen).toBe(true);
+    expect(overridden.supplyCap).toEqual(50);
+    expect(overridden.baseLTVasCollateral).toEqual(8000);
+    expect(overridden.usageAsCollateralEnabled).toBe(true);
+    // source untouched
+    expect(asset.reserveLiquidationThreshold).toEqual(8250);
+  });
+});
+
+describe("flattenRiskOverrides", () => {
+  test("lists every overridden field", () => {
+    const entries = flattenRiskOverrides({
+      v: 1,
+      assets: { WETH: { ltv: 7000, isFrozen: true } },
+      eModeCategories: { "1": { liquidationThreshold: 9000 } },
+    });
+
+    expect(entries).toHaveLength(3);
+    expect(entries).toContainEqual({
+      kind: "asset",
+      key: "WETH",
+      field: "ltv",
+      value: 7000,
+    });
+    expect(entries).toContainEqual({
+      kind: "asset",
+      key: "WETH",
+      field: "isFrozen",
+      value: true,
+    });
+    expect(entries).toContainEqual({
+      kind: "eModeCategory",
+      key: "1",
+      field: "liquidationThreshold",
+      value: 9000,
+    });
+  });
+
+  test("empty for absent overrides", () => {
+    expect(flattenRiskOverrides(undefined)).toEqual([]);
+    expect(flattenRiskOverrides(createEmptyRiskOverrides())).toEqual([]);
+  });
+});
+
+describe("encodeRiskConfig / decodeRiskConfig", () => {
+  const config: SharedRiskConfig = {
+    marketId: "ETHEREUM_V3",
+    overrides: {
+      v: 1,
+      assets: {
+        WETH: {
+          ltv: 7500,
+          liquidationThreshold: 8000,
+          eModeLtv: 9000,
+          eModeLiquidationThreshold: 9200,
+          supplyCap: 100000,
+          borrowCap: 50000,
+          borrowingEnabled: false,
+          usageAsCollateralEnabled: true,
+          isFrozen: true,
+          isPaused: false,
+        },
+        USDC: { borrowCap: 750000 },
+      },
+      eModeCategories: { "1": { ltv: 9100, liquidationThreshold: 9400 } },
+      meta: {
+        label: "Gauntlet update",
+        ref: "https://governance.aave.com/t/arfc-example/123",
+      },
+    },
+  };
+
+  test("round-trips a full config", () => {
+    const encoded = encodeRiskConfig(config);
+
+    expect(typeof encoded).toBe("string");
+    // url-safe: no +, /, =, or raw JSON characters
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const decoded = decodeRiskConfig(encoded, ["ETHEREUM_V3", "BASE_V3"]);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.marketId).toEqual("ETHEREUM_V3");
+    expect(decoded?.overrides.assets).toEqual(config.overrides.assets);
+    expect(decoded?.overrides.eModeCategories).toEqual(
+      config.overrides.eModeCategories
+    );
+    expect(decoded?.overrides.meta).toEqual(config.overrides.meta);
+  });
+
+  test("rejects unknown markets when a market list is provided", () => {
+    const encoded = encodeRiskConfig(config);
+    expect(decodeRiskConfig(encoded, ["BASE_V3"])).toBeNull();
+    // without a market list, market validity is the caller's concern
+    expect(decodeRiskConfig(encoded)).not.toBeNull();
+  });
+
+  test("rejects malformed payloads", () => {
+    expect(decodeRiskConfig("")).toBeNull();
+    expect(decodeRiskConfig("!!!not-base64url!!!")).toBeNull();
+    expect(decodeRiskConfig("aGVsbG8")).toBeNull(); // "hello" – not JSON
+    expect(decodeRiskConfig("x".repeat(10000))).toBeNull(); // oversized
+
+    const toB64Url = (value: string) =>
+      Buffer.from(value, "utf8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+    // wrong version
+    expect(
+      decodeRiskConfig(toB64Url(JSON.stringify({ v: 2, m: "ETHEREUM_V3" })))
+    ).toBeNull();
+    // missing market
+    expect(
+      decodeRiskConfig(
+        toB64Url(JSON.stringify({ v: 1, a: { WETH: { l: 5000 } } }))
+      )
+    ).toBeNull();
+    // no effective overrides after sanitization
+    expect(
+      decodeRiskConfig(
+        toB64Url(
+          JSON.stringify({
+            v: 1,
+            m: "ETHEREUM_V3",
+            a: { WETH: { l: -100, junk: 5 } },
+          })
+        )
+      )
+    ).toBeNull();
+  });
+
+  test("drops invalid fields but keeps the valid remainder", () => {
+    const toB64Url = (value: string) =>
+      Buffer.from(value, "utf8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+    const decoded = decodeRiskConfig(
+      toB64Url(
+        JSON.stringify({
+          v: 1,
+          m: "ETHEREUM_V3",
+          a: {
+            WETH: { t: 99999, l: -5, zz: 1 },
+            USDC: { bc: "750000" },
+          },
+          e: { "300": { l: 9000 }, "1": { t: 9100 } },
+        })
+      ),
+      ["ETHEREUM_V3"]
+    );
+
+    expect(decoded).not.toBeNull();
+    // t clamped to max bps, l dropped (negative), zz unknown
+    expect(decoded?.overrides.assets.WETH).toEqual({
+      liquidationThreshold: 10000,
+    });
+    // numeric strings are coerced
+    expect(decoded?.overrides.assets.USDC).toEqual({ borrowCap: 750000 });
+    // category 300 out of range, category 1 kept
+    expect(Object.keys(decoded?.overrides.eModeCategories || {})).toEqual([
+      "1",
+    ]);
+  });
+});

--- a/utils/riskOverrides.ts
+++ b/utils/riskOverrides.ts
@@ -1,0 +1,506 @@
+import { EModeCategoryData } from "./liquidEMode";
+
+/**
+ * Declarative, serializable overrides for per-asset (and per-eMode-category)
+ * risk parameters. Overrides are never written into fetched/working position
+ * data; they are applied at health-factor recompute time, so clearing an
+ * override always restores the on-chain values.
+ *
+ * All LTV / liquidation-threshold values are basis points (e.g. 8250 = 82.5%),
+ * matching on-chain units. Caps are whole-token amounts (0 = no cap).
+ */
+
+export type AssetRiskOverride = {
+  /** basis points */
+  ltv?: number;
+  /** basis points */
+  liquidationThreshold?: number;
+  /** legacy per-asset eMode LTV, basis points */
+  eModeLtv?: number;
+  /** legacy per-asset eMode liquidation threshold, basis points */
+  eModeLiquidationThreshold?: number;
+  /** whole tokens, 0 = uncapped */
+  supplyCap?: number;
+  /** whole tokens, 0 = uncapped */
+  borrowCap?: number;
+  borrowingEnabled?: boolean;
+  usageAsCollateralEnabled?: boolean;
+  isFrozen?: boolean;
+  isPaused?: boolean;
+};
+
+export type EModeCategoryOverride = {
+  /** basis points */
+  ltv?: number;
+  /** basis points */
+  liquidationThreshold?: number;
+};
+
+export type RiskParamOverrides = {
+  v: 1;
+  /** keyed by asset symbol */
+  assets: Record<string, AssetRiskOverride>;
+  /** keyed by eMode category id */
+  eModeCategories?: Record<string, EModeCategoryOverride>;
+  meta?: {
+    /** short human label, e.g. "Gauntlet 2026-08 param update" */
+    label?: string;
+    /** reference url, e.g. an Aave governance forum post */
+    ref?: string;
+  };
+};
+
+/** A decoded shareable config: overrides pinned to a specific market. */
+export type SharedRiskConfig = {
+  marketId: string;
+  overrides: RiskParamOverrides;
+};
+
+export const createEmptyRiskOverrides = (): RiskParamOverrides => ({
+  v: 1,
+  assets: {},
+});
+
+const NUMERIC_ASSET_FIELDS = [
+  "ltv",
+  "liquidationThreshold",
+  "eModeLtv",
+  "eModeLiquidationThreshold",
+  "supplyCap",
+  "borrowCap",
+] as const;
+
+const BOOLEAN_ASSET_FIELDS = [
+  "borrowingEnabled",
+  "usageAsCollateralEnabled",
+  "isFrozen",
+  "isPaused",
+] as const;
+
+const BPS_FIELDS: ReadonlySet<string> = new Set([
+  "ltv",
+  "liquidationThreshold",
+  "eModeLtv",
+  "eModeLiquidationThreshold",
+]);
+
+const MAX_BPS = 10000;
+
+const sanitizeNumber = (field: string, value: unknown): number | undefined => {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return undefined;
+  if (BPS_FIELDS.has(field)) return Math.min(Math.round(num), MAX_BPS);
+  return num;
+};
+
+const sanitizeAssetOverride = (
+  raw: unknown
+): AssetRiskOverride | undefined => {
+  if (!raw || typeof raw !== "object") return undefined;
+  const source = raw as Record<string, unknown>;
+  const clean: AssetRiskOverride = {};
+
+  NUMERIC_ASSET_FIELDS.forEach((field) => {
+    if (source[field] === undefined || source[field] === null) return;
+    const value = sanitizeNumber(field, source[field]);
+    if (value !== undefined) clean[field] = value;
+  });
+
+  BOOLEAN_ASSET_FIELDS.forEach((field) => {
+    if (typeof source[field] === "boolean") clean[field] = source[field] as boolean;
+  });
+
+  // Aave invariant: liquidation threshold >= LTV. When both are overridden,
+  // cap the LTV at the LT rather than producing an impossible pair.
+  if (
+    clean.ltv !== undefined &&
+    clean.liquidationThreshold !== undefined &&
+    clean.ltv > clean.liquidationThreshold
+  ) {
+    clean.ltv = clean.liquidationThreshold;
+  }
+  if (
+    clean.eModeLtv !== undefined &&
+    clean.eModeLiquidationThreshold !== undefined &&
+    clean.eModeLtv > clean.eModeLiquidationThreshold
+  ) {
+    clean.eModeLtv = clean.eModeLiquidationThreshold;
+  }
+
+  return Object.keys(clean).length ? clean : undefined;
+};
+
+const sanitizeEModeCategoryOverride = (
+  raw: unknown
+): EModeCategoryOverride | undefined => {
+  if (!raw || typeof raw !== "object") return undefined;
+  const source = raw as Record<string, unknown>;
+  const clean: EModeCategoryOverride = {};
+  (["ltv", "liquidationThreshold"] as const).forEach((field) => {
+    if (source[field] === undefined || source[field] === null) return;
+    const value = sanitizeNumber(field, source[field]);
+    if (value !== undefined) clean[field] = value;
+  });
+  if (
+    clean.ltv !== undefined &&
+    clean.liquidationThreshold !== undefined &&
+    clean.ltv > clean.liquidationThreshold
+  ) {
+    clean.ltv = clean.liquidationThreshold;
+  }
+  return Object.keys(clean).length ? clean : undefined;
+};
+
+/**
+ * Defensively validate/clamp an override object (e.g. decoded from a URL).
+ * Unknown fields are dropped, numbers are clamped to sane ranges, and empty
+ * structures are pruned.
+ */
+export const sanitizeRiskOverrides = (raw: unknown): RiskParamOverrides => {
+  const clean = createEmptyRiskOverrides();
+  if (!raw || typeof raw !== "object") return clean;
+  const source = raw as Record<string, unknown>;
+
+  const assets = source.assets;
+  if (assets && typeof assets === "object") {
+    Object.entries(assets as Record<string, unknown>).forEach(
+      ([symbol, override]) => {
+        if (typeof symbol !== "string" || !symbol.length || symbol.length > 64)
+          return;
+        const cleanOverride = sanitizeAssetOverride(override);
+        if (cleanOverride) clean.assets[symbol] = cleanOverride;
+      }
+    );
+  }
+
+  const categories = source.eModeCategories;
+  if (categories && typeof categories === "object") {
+    Object.entries(categories as Record<string, unknown>).forEach(
+      ([id, override]) => {
+        const numericId = Number(id);
+        if (!Number.isInteger(numericId) || numericId < 0 || numericId > 255)
+          return;
+        const cleanOverride = sanitizeEModeCategoryOverride(override);
+        if (cleanOverride) {
+          if (!clean.eModeCategories) clean.eModeCategories = {};
+          clean.eModeCategories[String(numericId)] = cleanOverride;
+        }
+      }
+    );
+  }
+
+  const meta = source.meta;
+  if (meta && typeof meta === "object") {
+    const { label, ref } = meta as Record<string, unknown>;
+    const cleanMeta: RiskParamOverrides["meta"] = {};
+    if (typeof label === "string" && label.trim().length)
+      cleanMeta.label = label.trim().slice(0, 140);
+    if (typeof ref === "string" && /^https?:\/\//i.test(ref.trim()))
+      cleanMeta.ref = ref.trim().slice(0, 500);
+    if (Object.keys(cleanMeta).length) clean.meta = cleanMeta;
+  }
+
+  return clean;
+};
+
+export const hasAnyRiskOverrides = (
+  overrides?: RiskParamOverrides | null
+): boolean => {
+  if (!overrides) return false;
+  if (Object.keys(overrides.assets || {}).length) return true;
+  if (Object.keys(overrides.eModeCategories || {}).length) return true;
+  return false;
+};
+
+/**
+ * Merge two override sets; fields from `priority` win over `base`.
+ * Used to layer the user's manual edits on top of a shared URL config.
+ */
+export const mergeRiskOverrides = (
+  base?: RiskParamOverrides | null,
+  priority?: RiskParamOverrides | null
+): RiskParamOverrides => {
+  const merged = createEmptyRiskOverrides();
+
+  [base, priority].forEach((source) => {
+    if (!source) return;
+    Object.entries(source.assets || {}).forEach(([symbol, override]) => {
+      merged.assets[symbol] = { ...merged.assets[symbol], ...override };
+    });
+    Object.entries(source.eModeCategories || {}).forEach(([id, override]) => {
+      if (!merged.eModeCategories) merged.eModeCategories = {};
+      merged.eModeCategories[id] = {
+        ...merged.eModeCategories[id],
+        ...override,
+      };
+    });
+    if (source.meta) merged.meta = { ...merged.meta, ...source.meta };
+  });
+
+  return merged;
+};
+
+/**
+ * Return eMode categories with any category-level overrides applied.
+ * Returns the original array when there is nothing to apply.
+ */
+export const applyEModeCategoryOverrides = (
+  eModes: EModeCategoryData[] | undefined,
+  overrides?: RiskParamOverrides | null
+): EModeCategoryData[] | undefined => {
+  const categoryOverrides = overrides?.eModeCategories;
+  if (!eModes?.length || !categoryOverrides) return eModes;
+  if (!Object.keys(categoryOverrides).length) return eModes;
+
+  return eModes.map((category) => {
+    const override = categoryOverrides[String(category.id)];
+    if (!override) return category;
+    return {
+      ...category,
+      ltv: override.ltv ?? category.ltv,
+      liquidationThreshold:
+        override.liquidationThreshold ?? category.liquidationThreshold,
+    };
+  });
+};
+
+/**
+ * A minimal shape of AssetDetails that override application cares about.
+ * (Kept structural to avoid a runtime import cycle with hooks/useAaveData.)
+ */
+type OverridableAssetFields = {
+  symbol: string;
+  baseLTVasCollateral: number;
+  reserveLiquidationThreshold: number;
+  eModeLtv?: number;
+  eModeLiquidationThreshold?: number;
+  supplyCap?: number;
+  borrowCap?: number;
+  borrowingEnabled?: boolean;
+  usageAsCollateralEnabled: boolean;
+  isFrozen?: boolean;
+  isPaused?: boolean;
+};
+
+/**
+ * Return a copy of the asset with override fields applied. Useful for
+ * display and gating (e.g. the add-asset dialog); position math applies
+ * overrides directly in updateDerivedHealthFactorData instead.
+ */
+export const applyRiskOverridesToAsset = <T extends OverridableAssetFields>(
+  asset: T,
+  overrides?: RiskParamOverrides | null
+): T => {
+  const override = overrides?.assets?.[asset.symbol];
+  if (!override) return asset;
+  return {
+    ...asset,
+    baseLTVasCollateral: override.ltv ?? asset.baseLTVasCollateral,
+    reserveLiquidationThreshold:
+      override.liquidationThreshold ?? asset.reserveLiquidationThreshold,
+    eModeLtv: override.eModeLtv ?? asset.eModeLtv,
+    eModeLiquidationThreshold:
+      override.eModeLiquidationThreshold ?? asset.eModeLiquidationThreshold,
+    supplyCap: override.supplyCap ?? asset.supplyCap,
+    borrowCap: override.borrowCap ?? asset.borrowCap,
+    borrowingEnabled: override.borrowingEnabled ?? asset.borrowingEnabled,
+    usageAsCollateralEnabled:
+      override.usageAsCollateralEnabled ?? asset.usageAsCollateralEnabled,
+    isFrozen: override.isFrozen ?? asset.isFrozen,
+    isPaused: override.isPaused ?? asset.isPaused,
+  };
+};
+
+/** Flat list of individual overridden fields, for diff chips/banners. */
+export type RiskOverrideEntry = {
+  kind: "asset" | "eModeCategory";
+  /** asset symbol or eMode category id */
+  key: string;
+  field: string;
+  value: number | boolean;
+};
+
+export const flattenRiskOverrides = (
+  overrides?: RiskParamOverrides | null
+): RiskOverrideEntry[] => {
+  if (!overrides) return [];
+  const entries: RiskOverrideEntry[] = [];
+  Object.entries(overrides.assets || {}).forEach(([symbol, override]) => {
+    Object.entries(override).forEach(([field, value]) => {
+      if (value === undefined) return;
+      entries.push({ kind: "asset", key: symbol, field, value });
+    });
+  });
+  Object.entries(overrides.eModeCategories || {}).forEach(([id, override]) => {
+    Object.entries(override).forEach(([field, value]) => {
+      if (value === undefined) return;
+      entries.push({ kind: "eModeCategory", key: id, field, value });
+    });
+  });
+  return entries;
+};
+
+/**
+ *
+ *  *** Shareable URL config encoding ***
+ *
+ * Compact, versioned, defensively-parsed format:
+ * base64url(JSON) with single-letter field keys to keep URLs short.
+ *
+ */
+
+const ASSET_FIELD_TO_COMPACT: Record<keyof AssetRiskOverride, string> = {
+  ltv: "l",
+  liquidationThreshold: "t",
+  eModeLtv: "el",
+  eModeLiquidationThreshold: "et",
+  supplyCap: "sc",
+  borrowCap: "bc",
+  borrowingEnabled: "b",
+  usageAsCollateralEnabled: "c",
+  isFrozen: "f",
+  isPaused: "p",
+};
+
+const COMPACT_TO_ASSET_FIELD: Record<string, keyof AssetRiskOverride> =
+  Object.fromEntries(
+    Object.entries(ASSET_FIELD_TO_COMPACT).map(([field, compact]) => [
+      compact,
+      field as keyof AssetRiskOverride,
+    ])
+  );
+
+const toBase64Url = (value: string): string => {
+  const base64 =
+    typeof window !== "undefined" && typeof window.btoa === "function"
+      ? window.btoa(
+        String.fromCharCode(...new TextEncoder().encode(value))
+      )
+      : Buffer.from(value, "utf8").toString("base64");
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const fromBase64Url = (value: string): string => {
+  const base64 =
+    value.replace(/-/g, "+").replace(/_/g, "/") +
+    "=".repeat((4 - (value.length % 4)) % 4);
+  if (typeof window !== "undefined" && typeof window.atob === "function") {
+    const binary = window.atob(base64);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  }
+  return Buffer.from(base64, "base64").toString("utf8");
+};
+
+/** Encode a market-scoped override config into a URL-safe string. */
+export const encodeRiskConfig = (config: SharedRiskConfig): string => {
+  const compact: Record<string, unknown> = {
+    v: 1,
+    m: config.marketId,
+  };
+
+  const assets: Record<string, Record<string, number | boolean>> = {};
+  Object.entries(config.overrides.assets || {}).forEach(
+    ([symbol, override]) => {
+      const compactOverride: Record<string, number | boolean> = {};
+      Object.entries(override).forEach(([field, value]) => {
+        if (value === undefined) return;
+        const key = ASSET_FIELD_TO_COMPACT[field as keyof AssetRiskOverride];
+        if (key) compactOverride[key] = value;
+      });
+      if (Object.keys(compactOverride).length)
+        assets[symbol] = compactOverride;
+    }
+  );
+  if (Object.keys(assets).length) compact.a = assets;
+
+  const categories: Record<string, Record<string, number>> = {};
+  Object.entries(config.overrides.eModeCategories || {}).forEach(
+    ([id, override]) => {
+      const compactOverride: Record<string, number> = {};
+      if (override.ltv !== undefined) compactOverride.l = override.ltv;
+      if (override.liquidationThreshold !== undefined)
+        compactOverride.t = override.liquidationThreshold;
+      if (Object.keys(compactOverride).length)
+        categories[id] = compactOverride;
+    }
+  );
+  if (Object.keys(categories).length) compact.e = categories;
+
+  if (config.overrides.meta?.label) compact.n = config.overrides.meta.label;
+  if (config.overrides.meta?.ref) compact.r = config.overrides.meta.ref;
+
+  return toBase64Url(JSON.stringify(compact));
+};
+
+/**
+ * Decode and validate a shared config string. Returns null when the payload
+ * is malformed or references an unknown market; individual invalid fields
+ * are dropped rather than failing the whole config.
+ */
+export const decodeRiskConfig = (
+  encoded: string,
+  validMarketIds?: string[]
+): SharedRiskConfig | null => {
+  if (!encoded || typeof encoded !== "string" || encoded.length > 8192)
+    return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fromBase64Url(encoded));
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object") return null;
+  const source = parsed as Record<string, unknown>;
+  if (source.v !== 1) return null;
+
+  const marketId = source.m;
+  if (typeof marketId !== "string" || !marketId.length) return null;
+  if (validMarketIds && !validMarketIds.includes(marketId)) return null;
+
+  // Expand compact keys back to full field names, then run the standard
+  // sanitizer so URL payloads get the same clamping as any other input.
+  const rawOverrides: Record<string, unknown> = {};
+
+  if (source.a && typeof source.a === "object") {
+    const assets: Record<string, Record<string, unknown>> = {};
+    Object.entries(source.a as Record<string, unknown>).forEach(
+      ([symbol, compactOverride]) => {
+        if (!compactOverride || typeof compactOverride !== "object") return;
+        const expanded: Record<string, unknown> = {};
+        Object.entries(compactOverride as Record<string, unknown>).forEach(
+          ([compactKey, value]) => {
+            const field = COMPACT_TO_ASSET_FIELD[compactKey];
+            if (field) expanded[field] = value;
+          }
+        );
+        assets[symbol] = expanded;
+      }
+    );
+    rawOverrides.assets = assets;
+  }
+
+  if (source.e && typeof source.e === "object") {
+    const categories: Record<string, Record<string, unknown>> = {};
+    Object.entries(source.e as Record<string, unknown>).forEach(
+      ([id, compactOverride]) => {
+        if (!compactOverride || typeof compactOverride !== "object") return;
+        const compact = compactOverride as Record<string, unknown>;
+        categories[id] = {
+          ltv: compact.l,
+          liquidationThreshold: compact.t,
+        };
+      }
+    );
+    rawOverrides.eModeCategories = categories;
+  }
+
+  rawOverrides.meta = { label: source.n, ref: source.r };
+
+  const overrides = sanitizeRiskOverrides(rawOverrides);
+  if (!hasAnyRiskOverrides(overrides)) return null;
+
+  return { marketId, overrides };
+};

--- a/utils/riskOverrides.ts
+++ b/utils/riskOverrides.ts
@@ -372,11 +372,15 @@ const COMPACT_TO_ASSET_FIELD: Record<string, keyof AssetRiskOverride> =
 
 const toBase64Url = (value: string): string => {
   const base64 =
-    typeof window !== "undefined" && typeof window.btoa === "function"
-      ? window.btoa(
-        String.fromCharCode(...new TextEncoder().encode(value))
-      )
-      : Buffer.from(value, "utf8").toString("base64");
+    typeof Buffer !== "undefined"
+      ? Buffer.from(value, "utf8").toString("base64")
+      : // UTF-8 encode via percent-escapes so btoa only sees byte values
+      window.btoa(
+        encodeURIComponent(value).replace(
+          /%([0-9A-F]{2})/g,
+          (_match, hex: string) => String.fromCharCode(parseInt(hex, 16))
+        )
+      );
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 };
 
@@ -384,12 +388,18 @@ const fromBase64Url = (value: string): string => {
   const base64 =
     value.replace(/-/g, "+").replace(/_/g, "/") +
     "=".repeat((4 - (value.length % 4)) % 4);
-  if (typeof window !== "undefined" && typeof window.atob === "function") {
-    const binary = window.atob(base64);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-    return new TextDecoder().decode(bytes);
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(base64, "base64").toString("utf8");
   }
-  return Buffer.from(base64, "base64").toString("utf8");
+  const binary = window.atob(base64);
+  return decodeURIComponent(
+    binary
+      .split("")
+      .map(
+        (char) => `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`
+      )
+      .join("")
+  );
 };
 
 /** Encode a market-scoped override config into a URL-safe string. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issues [#16](https://github.com/0xCazador/defi-simulator/issues/16) (edit risk parameters per asset) and [#17](https://github.com/0xCazador/defi-simulator/issues/17) (shareable risk config URLs) as one coherent system built on a declarative override layer.

### Override engine (`utils/riskOverrides.ts`)

- `RiskParamOverrides`: versioned, serializable per-market overrides for asset LTV / liquidation threshold (base and e-mode, in bps), supply/borrow caps, and protocol flags (`borrowingEnabled`, `usageAsCollateralEnabled`, `isFrozen`, `isPaused`), plus e-mode **category** overrides (category values win for e-mode collateral, matching Aave semantics).
- Overrides are applied at recompute time inside `updateDerivedHealthFactorData` / `resolveEffectiveRiskParams` inputs — fetched values are never mutated, so clearing an override always restores on-chain parameters, and overrides survive quantity/price resets and refetches.
- Defensive sanitization (bps clamped 0–10000, LT ≥ LTV invariant, caps ≥ 0, unknown fields dropped) shared by the editor, URL decoding, and the wizard.
- Compact base64url codec (`encodeRiskConfig`/`decodeRiskConfig`) with single-letter keys; a realistic config fits comfortably in a URL (~230 chars).

### Per-asset editor (#16)

- `RiskParamsEditor` mounted in both asset details dialogs and via a new "tune" icon on every asset row, using the app's established edited-state language: yellow indicators, dimmed `original ➔ new` diffs, per-field reset.
- E-mode aware: for e-mode collateral it explains that category values are in effect and lets you edit the category (liquid e-modes) or the legacy per-asset e-mode fields.
- Caps don't enter HF math (as in Aave) — instead, rows show "Exceeds supply/borrow cap" warning badges; flag overrides gate the add-asset dialog.
- A position-level chip next to the health factor lists all active overrides with originals, offers clear-all and one-click "copy shareable link".

### Shareable configs (#17)

- `?config=` URLs are validated on load; invalid payloads show a dismissible notice and are dropped from the URL, never crash.
- `ConfigBanner` explains the active config (label, per-change diff list, governance reference link) with a live **Apply to simulation** toggle — flipping it recomputes HF/borrowing power instantly.
- `ConfiguratorDialog` wizard (market → assets → parameters → review) generates links with optional label + governance-forum reference, and can apply the config immediately.
- Manual edits layer on top of a shared config (manual wins field-by-field), so recipients can tinker from a shared baseline and re-share.

## Testing

- 36 new tests (`test/utils/riskOverrides.test.ts`, `test/hooks/riskOverridesSim.test.ts`): sanitization clamps, merge precedence, codec round-trips and hostile-input parsing, override math against hand-computed positions, liquid + legacy e-mode interactions, hook mutators, independent reset scopes, shared-config toggling.
- Full suite: **1842 passed** (1806 baseline + 36 new). Production `next build` succeeds.
- Browser smoke test (dev server): banner renders with change list/toggle/reference for a valid `?config=`, invalid payloads show the red notice and strip the param, splash unaffected.
- Live-chain manual testing wasn't possible in this environment (no `NEXT_PUBLIC_ALCHEMY_API_KEY`).

Note: the plan mentioned enriching JSON fixtures; the new suite instead uses a purpose-built synthetic position factory (with caps, reserve ids, and liquid/legacy e-mode variants), which keeps the large fixture file untouched while covering the same ground deterministically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0263e2bc-774f-441e-861a-1960b7765671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0263e2bc-774f-441e-861a-1960b7765671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

